### PR TITLE
Fix package setup to allow pip installations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,3 +34,30 @@ Alpha release verison of pyaxe for testing.
 This version should complete for both regular extraction and optimal extraction, except optimal extraction still has a bug in the final STP and SPC files, which may have blank data.
 
 submit all bugs and problems to the issue tracker for this repository
+
+
+
+Some feature notes from the previous IRAF software package
+----------------------------------------------------------
+- Version 2.4.4:
+    axeprep doesn't require direct image column for input list file
+
+- Version 2.4.3:
+    - #978 - added full support for astrodrizzle cases with dimen_info not zero
+    - #779 - check for subarray input images in axeprep and return an error
+    - #678 - dont do background subtraction in axeprep when < 10% pixels are deemed good
+    - #1033 - I put a catch in so that if the C code reports 0 good sky pixels no background subtraction is done and it doesn't fatal error out
+
+- Version 2.4.2:
+    - #1017 resolved. User reported an error with the "SCI" extension when the segementation image was read in fcubeprep. The code was updated to be more generic in the way headers are read and constructed.
+
+- Version 0.20: PyDrizzle will be automatically run to generate coeffs files
+    - if not already present for input image.
+
+- Version 0.21: Syntax for calling PyDrizzle updated for new 'bits' syntax.
+    - Created wtran to use wtraxy and wtranback, and hence be MUCH faster in
+      list mode.
+    - Updated 'raise' statements to use Exception class, to conform to latest
+      python syntax rules.
+
+- Version 0.12 for STSDAS 3.3 release, October 2004

--- a/README.md
+++ b/README.md
@@ -117,29 +117,3 @@ software:
     Richard Hook, ST-ECF/STScI
     Howard Bushouse, STScI
     Megan Sosey, STScI
-
-
-Some versioning feature notes from the previous IRAF software package:
-
-- Version 2.4.4:
-    axeprep doesn't require direct image column for input list file
-
-- Version 2.4.3:
-    - #978 - added full support for astrodrizzle cases with dimen_info not zero
-    - #779 - check for subarray input images in axeprep and return an error
-    - #678 - dont do background subtraction in axeprep when < 10% pixels are deemed good
-    - #1033 - I put a catch in so that if the C code reports 0 good sky pixels no background subtraction is done and it doesn't fatal error out
-
-- Version 2.4.2:
-    - #1017 resolved. User reported an error with the "SCI" extension when the segementation image was read in fcubeprep. The code was updated to be more generic in the way headers are read and constructed.
-
-- Version 0.20: PyDrizzle will be automatically run to generate coeffs files
-    - if not already present for input image.
-
-- Version 0.21: Syntax for calling PyDrizzle updated for new 'bits' syntax.
-    - Created wtran to use wtraxy and wtranback, and hence be MUCH faster in
-      list mode.
-    - Updated 'raise' statements to use Exception class, to conform to latest
-      python syntax rules.
-
-- Version 0.12 for STSDAS 3.3 release, October 2004

--- a/README.md
+++ b/README.md
@@ -1,62 +1,115 @@
+# hstaxe
 
-Current Requirements
-====================
-This version of the software no longer requires IRAF or PyRAF to be installed.
-see `setup.py` and `setup.cfg` for additional install dependencies. The most notable here are
-the GNU Science Library, cfitsio, and wcstools. 
-
-There are some dependency packages, such as cfitsio which are only available through the Astroconda channel. In order to ease setup of a conda environment with specific depenedencies, use the `conda_environment.yml` file to create a working environment on your system. Make sure that your conda environment. Packages from specific channels can be installed using the following syntax:
-
-`conda install wcstools --channel astroconda`
-
-If you want to add the astroconda channel to your default channels list:
-
-`conda config --add channels astroconda`
-
-Create an environment to run hstaxe, install jupyter to follow along in the tutorial cookbook:
-
-`conda create --name hstaxe python=3.7 jupyter`
+`hstaxe` is a Python package to extract spectra from all
+slitless spectroscopy modes provided by the [Hubble Space
+Telescope](https://www.stsci.edu/hst) [Wide Field Camera
+3 (WFC3)](https://www.stsci.edu/hst/instrumentation/wfc3)
+and the [Advanced Camera for Surveys
+(ACS)](https://www.stsci.edu/hst/instrumentation/acs). It supports the
+features provided by the previous IRAF-based aXe package.
 
 
-In order to build from source, make sure that you have the following installed locally 
-so that the C code will compile. The version listed below were used for the last release:
+## Installation
 
-    GNU Autoconf version 2.69
-    GNU Automake version 1.16.3
-    GNU Libtool version 2.4.6
+### Requirements
+
+`hstaxe` has the following Python requirements:
+
+  * Python 3.7 or later
+  * Numpy
+  * Astropy
+  * stwcs
+  * stsci.imagestats
+  * drizzlepac
+  * photutils < 1.1.0
+  * drizzle
+
+In addition to the above Python packages, `hstaxe` depends on the
+following C-based packages to be installed:
+
+  * cfitsio
+  * gsl
+  * [libwcs](http://tdc-www.harvard.edu/software/wcstools/subroutines/libwcs.wcs.html) from [wcstools](http://tdc-www.harvard.edu/wcstools/)
 
 
-Examples
-========
-There are a couple simple test scripts in hstaxe/tests that can be run against the example data in the aXe cookbook:
+### Installing using conda
 
-`run_acs_cookbook.py`: runs basic aXe against ACS data
+`hstaxe` can be installed with
+[conda](https://docs.conda.io/en/latest/) if you have installed
+[Anaconda](https://www.anaconda.com/products/individual) or
+[Miniconda](https://docs.conda.io/en/latest/miniconda.html)
+`hstaxe` is available via the [Astroconda
+channel](https://astroconda.readthedocs.io/en/latest) and can be
+installed by running:
 
-`run_cookbook.py`: runs basic aXe against WFC3 data
+    conda install hstaxe -c https://ssb.stsci.edu/astroconda
 
-`run_cookbook_part2.py`: runs axedrizzle against WFC3 data
 
-`aXe_WFC3_Cookbook.ipynb`: runs through a full WFC3 dataset cookbook style
- 
+### Installing using pip
+
+You will need a C compiler suite (e.g., ``gcc`` or ``clang``) to build
+`hstaxe` via [pip](https://pip.pypa.io/en/latest/) from either PyPI
+or from the source distribution. In addition to the above required
+packages, the following packages are required to build `hstaxe`:
+
+  * make
+  * automake
+  * autoconf
+  * libtool
+  * pkg-config
+
+Note that you may also need to install the
+[c-blosc](https://github.com/Blosc/c-blosc) package as a dependency
+of the [tables](https://pypi.org/project/tables/) package on certain
+platforms (e.g., this is currently needed for OSX and Windows with
+Python 3.9 due to missing `tables` wheels on PyPI).
+
+After all of the required packages are installed, to install the latest
+released version of `hstaxe` with `pip`, run (*NOTE this does not work
+for versions <= 1.0.0*):
+
+    pip install hstaxe
+
+The latest development version of the `hstaxe` source code can be
+retrieved and installed via:
+
+    git clone https://github.com/spacetelescope/hstaxe.git
+    cd hstaxe
+    pip install ".[all]"
+
+
+## Examples
+
+There are a couple simple test scripts in hstaxe/tests that can be run
+against the example data in the aXe cookbook:
+
+  * `run_acs_cookbook.py`: runs basic aXe against ACS data
+
+  * `run_cookbook.py`: runs basic aXe against WFC3 data
+
+  * `run_cookbook_part2.py`: runs axedrizzle against WFC3 data
+
+  * `aXe_WFC3_Cookbook.ipynb`: runs through a full WFC3 dataset cookbook style
+
 The aXe WFC3 cookbook data can be downloaded by cloning this repository:
-https://github.com/npirzkal/aXe_WFC3_Cookbook 
+https://github.com/npirzkal/aXe_WFC3_Cookbook
 
-The aXe ACS cookbook and associated data can be dowloaded from the following area:
-https://stsci.box.com/s/eo98zjtyccnoq7z73akfrx94jog3pg7j
+The aXe ACS cookbook and associated data can be downloaded from the
+following area: https://stsci.box.com/s/eo98zjtyccnoq7z73akfrx94jog3pg7j
 
 
+## Software Development History
 
-Software Development History
-============================
+This software was originally developed by the ACS group of the Space
+Telescope - European Coordinating Facility (ST-ECF). The ST-ECF is a
+department jointly run by the European Space Agency and the European
+Southern Observatory. It is located at the ESO headquarters at Garching
+near Munich. The ST-ECF staff supports the European astronomical
+community in exploiting the research opportunities provided by the
+earth-orbiting Hubble Space Telescope.
 
-This software was originally developed by the ACS group of the Space Telescope -
-European Coordinating Facility (ST-ECF). The ST-ECF is a department jointly
-run by the European Space Agency and the European Southern Observatory.
-It is located at the ESO headquarters at Garching near Munich. The ST-ECF
-staff supports the European astronomical community in exploiting the research
-opportunities provided by the earth-orbiting Hubble Space Telescope.
-
-The Developers have included, roughly in  order of who has worked on the software:
+The developers have included, roughly in order of who has worked on the
+software:
 
     Norbert Pirzkal, ST-ECF/STScI
     Markus Demleitner, ST-ECF
@@ -75,10 +128,10 @@ Some versioning feature notes from the previous IRAF software package:
     - #978 - added full support for astrodrizzle cases with dimen_info not zero
     - #779 - check for subarray input images in axeprep and return an error
     - #678 - dont do background subtraction in axeprep when < 10% pixels are deemed good
-    - #1033 - I put a catch in so that if the C code reports 0 good sky pixels no background subtraction is done and it doesn't fatal error out 
-   
-- Version 2.4.2:  
-    - #1017 resolved. User reported an error with the "SCI" extension when the segementation image was read in fcubeprep. The code was updated to be more generic in the way headers are read and constructed. 
+    - #1033 - I put a catch in so that if the C code reports 0 good sky pixels no background subtraction is done and it doesn't fatal error out
+
+- Version 2.4.2:
+    - #1017 resolved. User reported an error with the "SCI" extension when the segementation image was read in fcubeprep. The code was updated to be more generic in the way headers are read and constructed.
 
 - Version 0.20: PyDrizzle will be automatically run to generate coeffs files
     - if not already present for input image.
@@ -90,6 +143,3 @@ Some versioning feature notes from the previous IRAF software package:
       python syntax rules.
 
 - Version 0.12 for STSDAS 3.3 release, October 2004
-
-
-

--- a/cextern/configure.ac
+++ b/cextern/configure.ac
@@ -51,7 +51,7 @@ AS_IF([test "x$with_gsl" != "xno"], [
        GSL="$withval"
        ])
 
-AC_PATH_PROG([GSL_CONFIG], [gsl-config], [notfound],[$with_gsl:$PATH])	
+AC_PATH_PROG([GSL_CONFIG], [gsl-config], [notfound],[$with_gsl:$PATH])
 if test "$GSL_CONFIG" == "notfound"
   then
     AC_MSG_ERROR([gsl-config not found. See ./configure --help to know how to set a proper gsl path])
@@ -81,8 +81,8 @@ AS_IF([test "x$with_wcstools" != "xno"], [
        ])
 
 if test "x$GSL" != "x"; then
-    GSL_LIBS=`$GSL/bin/gsl-config --libs`
-    GSL_CFLAGS=`$GSL/bin/gsl-config --cflags`
+    GSL_LIBS=`$GSL_CONFIG --libs`
+    GSL_CFLAGS=`$GSL_CONFIG --cflags`
 else
     PKG_CHECK_MODULES([GSL], [gsl >= 1])
 fi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,8 +43,8 @@ conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 
 # General information about the project
-package = importlib.import_module(setup_cfg['package_name'])
-project = setup_cfg['package_name']
+package = importlib.import_module(setup_cfg['name'])
+project = setup_cfg['name']
 author = setup_cfg['author']
 copyright = '{0}, {1}'.format(datetime.datetime.now().year, author)
 
@@ -140,7 +140,7 @@ suppress_warnings = ['app.add_directive', ]
 # built documents.
 #
 # The short X.Y version.
-package = importlib.import_module(setup_cfg['package_name'])
+package = importlib.import_module(setup_cfg['name'])
 try:
     version = package.__version__.split('-', 1)[0]
     # The full version, including alpha/beta/rc tags.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel"]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "wheel", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     stwcs
     stsci.imagestats
     drizzlepac
+    photutils<1.1.0
     drizzle
 tests_require =
     backports.tempfile

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,14 @@
 [metadata]
-package_name = hstaxe
+name = hstaxe
 description = Spectral extraction tools for Hubble Space Telescope Grisms
 long_description = Spectral extraction tools for Hubble Space Telescope Grisms ala aXe
 author = hstaxe and aXe developers
+author_email = help@stsci.edu
 license = 3-Clause BSD
+license_file = LICENSE.txt
 url = https://github.com/spacetelescope/hstaxe
-
-classifier =
+github_project = spacetelescope/hstaxe
+classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: BSD License
     Development Status :: 4 - Beta
@@ -19,11 +21,9 @@ classifier =
 
 [options]
 python_requires >=3.7
-setup_requires =
-    setuptools_scm
-    setuptools
-packages =
-    hstaxe
+setup_requires = setuptools_scm
+packages = find:
+zip_safe = False
 install_requires =
     numpy
     astropy
@@ -37,13 +37,11 @@ tests_require =
     requests_mock
     pytest-catchlog
 
-
 [options.extras_require]
 docs =
     sphinx
     sphinx-automodapi
     sphinx_rtd_theme
-
 tests =
     pytest
 
@@ -64,5 +62,3 @@ pep8ignore = E501 W391
 [flake8]
 exclude = cextern
 select = E101 W191 W291 W292 W293 W391 E11 E502 E722 E901 E902
-
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifier =
 
 [options]
 python_requires >=3.7
-setup_requires = 
+setup_requires =
     setuptools_scm
     setuptools
 packages =
@@ -27,13 +27,10 @@ packages =
 install_requires =
     numpy
     astropy
-    cfitsio
-    gsl
     stwcs
     stsci.imagestats
     drizzlepac
     drizzle
-    wcstools
 tests_require =
     backports.tempfile
     pytest
@@ -68,4 +65,4 @@ pep8ignore = E501 W391
 exclude = cextern
 select = E101 W191 W291 W292 W293 W391 E11 E502 E722 E901 E902
 
- 
+

--- a/setup.py
+++ b/setup.py
@@ -207,34 +207,17 @@ class BuildExtWithConfigure(install):
 
         install.run(self)
 
-
-
-
 # Note that requires and provides should not be included in the call to
 # ``setup``, since these are now deprecated. See this link for more details:
 # https://groups.google.com/forum/#!topic/astropy-dev/urYO8ckB2uM
 
 setup(
-    name=metadata.get('package_name', 'imexam'),
-    provides=[metadata.get('package_name', 'imexam')],
-    description=metadata.get('description'),
-    long_description=metadata.get('long_description'),
-    author=metadata.get('author'),
-    author_email=metadata.get('author_email'),
-    url=metadata.get('url'),
-    license=metadata.get('license'),
-    classifiers=metadata.get('classifier'),
-    zip_safe=False,
     use_scm_version=True,
-    use_2to3=False,
-    setup_requires=['setuptools_scm'],
-    packages=find_packages(),
     cmdclass={
         'test': PyTest,
         'build_sphinx': BuildSphinx,
         'build_ext': BuildExtWithConfigure,
         'install': BuildExtWithConfigure,
         'clean': MyClean,
-    },
-    package_dir={'': '.'},
+    }
 )


### PR DESCRIPTION
As noted in #19, `hstaxe` cannot currently be installed using `pip` (from either PyPI or from package source).  This is because the package `setup.cfg` lists non-Python dependencies (e.g., `cfitsio`), which `setuptools` cannot resolve/satisfy because they are pure C packages. With the current setup, `hstaxe` can never be installed via `pip`.

This PR fixes the package setup and adds detailed installation instructions to the [README](https://github.com/larrybradley/hstaxe/tree/setup-install#readme) noting the non-Python dependencies (both build-time and run-time) that are required to be installed before installing `hstaxe` via `pip`.

After installing the required dependencies noted in the [README](https://github.com/larrybradley/hstaxe/tree/setup-install#readme), this PR can be tested by running:

```
git clone -b setup-install https://github.com/larrybradley/hstaxe.git
cd hstaxe
pip install ".[all]"
```

I've verified that this works on OSX with Python 3.9.

A new version of `hstaxe` will need to be released and uploaded to PyPI for `pip install hstaxe` to work.  This is noted in the README.

CC: @ivastar 

Fixes #19.

EDIT:  I pinned `photutils < 1.1.0` because of a bug in `drizzlepac`.  After the next `drizzlepac` release, this specific `photutils` dependency can be removed.