### PR TITLE
Retain backward compatibility with Astropy < 4.3

### DIFF
--- a/hstaxe/axesrc/fcubeobjs.py
+++ b/hstaxe/axesrc/fcubeobjs.py
@@ -722,8 +722,8 @@ class FluxImage:
 
         if (ftype == 'mef'):
             scihdr = file_a['SCI'].header
-            scihdr.strip()
-            newhdr = fits.Header(prihdr + scihdr)
+#             scihdr.strip()
+            newhdr = fits.Header(prihdr + scihdr.copy(strip=True))
             data = file_a['SCI'].data
         else:
             newhdr = fits.Header(prihdr)


### PR DESCRIPTION
I have had issues with getting older versions of photutils that are compatible with hstaxe to work with astropy newer than ~4.1. Because of this, Header.strip() method was still not available. This causes an error in only one place. This proposed change with retain the functionality, but keep hstaxe backward compatible with older astropy. 

instead of:
scihdr.strip()
newhdr = fits.Header(prihdr + scihdr)

We can do: newhdr = fits.Header(prihdr + scihdr.copy(strip=True))