### PR TITLE
Unpin photutils version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     stwcs
     stsci.imagestats
     drizzlepac
-    photutils<1.1.0
     drizzle
 
 [options.extras_require]


### PR DESCRIPTION
The `photutils` version pin was due to `drizzlepac` requiring `photutils < 1.1.0`.  In this PR I've remove `photutils` from the required dependency list.  `photutils` is a required dependency of `drizzlepac`, which is a required dependency of `hstaxe`. The `drizzlepac`-supported `photutils` version will be installed when `drizzlepac` is installed.

Closes #26 