### PR TITLE
Add readthedocs.yml, minor edit to setup

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
   builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  apt_packages:
+    - graphviz
+  tools:
+    python: "3.9"
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  system_packages: false
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,8 @@ test =
 docs =
     sphinx
     sphinx-automodapi
-    sphinx_rtd_theme
-    stsci_rtd_theme
+    sphinx-rtd-theme
+    stsci-rtd-theme
 
 [build_sphinx]
 source-dir = docs


### PR DESCRIPTION
We need the `.readthedocs.yml` file so that `stsci-rtd-theme` will be installed as part of the docs build. There might be more changes needed after this, not sure yet.