### PR TITLE
Enable missing background flag in GOL2AF for local background subtraction

### DIFF
--- a/hstaxe/axesrc/axelowlev.py
+++ b/hstaxe/axesrc/axelowlev.py
@@ -629,7 +629,7 @@ class aXe_GOL2AF(TaskWrapper):
     def __init__(self, grism, config,
                  slitless_geom=True,
                  orient=True,
-                 back=False, **params):
+                 **params):
         """Generates an aperture file from a grism object list.
 
         Parameters
@@ -816,7 +816,7 @@ class aXe_GOL2AF(TaskWrapper):
             self.command_list.append('-exclude_faint')
 
         #  append the flag 'bck'
-        if (('back' in params) and (params['back'])):
+        if params.get('back', False):
             # put the bck-flag to the list
             self.command_list.append('-bck')
         _log.info("Command list: {}".format(self.command_list))

--- a/hstaxe/axesrc/axetasks.py
+++ b/hstaxe/axesrc/axetasks.py
@@ -214,8 +214,8 @@ def axecore(inlist='',
             model_scale=None,
             inter_type='linear',
             lambda_psf=None,
-            np=None,
-            interp=None,
+            np=10,  # Default value retrieved from hstaxe manual: https://hstaxe.readthedocs.io/en/latest/hstaxe/axe_tasks.html?highlight=interp#backest # noqa
+            interp=0,  # Default value retrieved from hstaxe manual: https://hstaxe.readthedocs.io/en/latest/hstaxe/axe_tasks.html?highlight=interp#backest # noqa
             niter_med=None,
             niter_fit=None,
             kappa=None,

--- a/hstaxe/axesrc/axetasks.py
+++ b/hstaxe/axesrc/axetasks.py
@@ -682,7 +682,6 @@ def gol2af(grism='',
 
     # run GOL2AF
     gol2af = axelowlev.aXe_GOL2AF(grism, config,
-                                  back=back,
                                   mfwhm=mfwhm,
                                   orient=orient,
                                   slitless_geom=slitless_geom,
@@ -690,7 +689,8 @@ def gol2af(grism='',
                                   lambda_mark=lambda_mark,
                                   dmag=dmag,
                                   in_gol=in_gol,
-                                  out_af=out_af)
+                                  out_af=out_af,
+                                  back=back)
     gol2af.run()
 
 


### PR DESCRIPTION
Two weeks of spelunking to get 4 diffs, such is the cost of debugging in C; new developers take heed lest ye fall as did I! 

The way each of the python wrapper subroutines were written was to check if each argument existed in the catch all `**params` argument and if so, chain them into the command list. In GOL2AF, `back` was set as an explicit, named argument in the function definition. As such, `back` would never have been found in the `**params` dictionary. I opted to remove this named argument from the function declaration such that the `back` argument would therefore be added to the `**params` dictionary.

I'll also add a modified version of @st-apidgeon's testing notebook demonstrating the local background subtraction code running