### PR TITLE
Add missing colon in inputchecks

### DIFF
--- a/hstaxe/axesrc/inputchecks.py
+++ b/hstaxe/axesrc/inputchecks.py
@@ -159,7 +159,7 @@ class InputChecker:
 
         # check for background subtraction
         if backgr:
-            if backims in (None, "")
+            if backims in (None, ""):
                 err_msg = ("{0:s}: A background image must be given for the "
                            "background subtraction!".format(self.taskname))
                 raise aXeError(err_msg)


### PR DESCRIPTION
This got merged with a syntax error somehow. This fixes it.