### PR TITLE
DOC: Build RTD without pkg install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,72 @@
+# Compiled files
+*.py[cod]
+*.a
+*.o
+*.so
+__pycache__
+
+# Ignore .c files by default to avoid including generated code. If you want to
+# add a non-generated .c extension, use `git add -f filename.c`.
+*.c
+
+# Other generated files
+*/version.py
+*/cython_version.py
+htmlcov
+.coverage
+MANIFEST
+.ipynb_checkpoints
+notebooks/*.fits
+
+# Sphinx
+docs/api
+docs/_build
+
+# Eclipse editor project files
+.project
+.pydevproject
+.settings
+
+# Pycharm editor project files
+.idea
+
+# Floobits project files
+.floo
+.flooignore
+
+# Packages/installer info
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+distribute-*.tar.gz
+
+# Other
+.cache
+.tox
+.*.sw[op]
+*~
+._*
+.project
+.pydevproject
+.settings
+pip-wheel-metadata
+.vscode
+.pytest_cache
+.tmp
+.eggs
+.python-version
+
+# Mac OSX
+.DS_Store
+
+# Environments
+/env*
+/*venv

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,12 +10,9 @@ build:
 sphinx:
   builder: html
   configuration: docs/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 
 python:
   system_packages: false
   install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,18 +34,15 @@ def setup(app):
 
 conf = ConfigParser()
 
-sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath('hstaxe/'))
 sys.path.insert(0, os.path.abspath('exts/'))
 
 # -- General configuration ---------------------------------------------------
-conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
-setup_cfg = dict(conf.items('metadata'))
 
 # General information about the project
-package = importlib.import_module(setup_cfg['name'])
-project = setup_cfg['name']
-author = setup_cfg['author']
+package = 'hstaxe'
+project = 'hstaxe'
+author = 'STScI'
 copyright = '{0}, {1}'.format(datetime.datetime.now().year, author)
 
 # The version info for the project you're documenting, acts as replacement for
@@ -53,13 +50,7 @@ copyright = '{0}, {1}'.format(datetime.datetime.now().year, author)
 # built documents.
 #
 # The short X.Y version.
-try:
-    version = package.__version__.split('-', 1)[0]
-    # The full version, including alpha/beta/rc tags.
-    release = package.__version__
-except AttributeError:
-    version = 'dev'
-    release = 'dev'
+version = release = '1.0.1'
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.3'
@@ -89,15 +80,8 @@ intersphinx_mapping = {
 # ones.
 extensions = [
     'numfig',
-    'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.inheritance_diagram',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.imgmath',
     'sphinx.ext.mathjax',
     ]
 
@@ -135,23 +119,9 @@ exclude_patterns = ['_build']
 suppress_warnings = ['app.add_directive', ]
 
 
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-#
-# The short X.Y version.
-package = importlib.import_module(setup_cfg['name'])
-try:
-    version = package.__version__.split('-', 1)[0]
-    # The full version, including alpha/beta/rc tags.
-    release = package.__version__
-except AttributeError:
-    version = 'dev'
-    release = 'dev'
-
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
-rst_epilog = """.. _hstaxe: high-level_API.html"""
+#rst_epilog = """.. _hstaxe: high-level_API.html"""
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -160,13 +130,13 @@ default_role = 'obj'
 
 # Don't show summaries of the members in each class along with the
 # class' docstring
-numpydoc_show_class_members = False
+#numpydoc_show_class_members = False
 
-autosummary_generate = True
+#autosummary_generate = True
 
 # Class documentation should contain *both* the class docstring and
 # the __init__ docstring
-autoclass_content = "both"
+#autoclass_content = "both"
 
 # Render inheritance diagrams in SVG
 graphviz_output_format = "svg"

--- a/docs/hstaxe/axe_tasks.rst
+++ b/docs/hstaxe/axe_tasks.rst
@@ -271,7 +271,9 @@ drzfwhm in the task axecore must correspond to the values to be used for
 parameters infwhm and outfwhm in the task axedrizzle, respectively. The
 extraction width used after drizzling, which is specified via drzfwhm
 and outfwhm, must be larger than the extraction width for the PETs in
-axecore, which is set by extrfwhm (see :ref:`axedrizzle_task`).
+axecore, which is set by extrfwhm.
+
+.. (see :ref:`axedrizzle_task`)
 
 Usage
 ~~~~~

--- a/docs/hstaxe/configuration_files.rst
+++ b/docs/hstaxe/configuration_files.rst
@@ -1,4 +1,4 @@
-.. _configuration_files:
+.. _configuration_files_main_section:
 
 Configuration of aXe tasks
 ==========================

--- a/docs/hstaxe/description.rst
+++ b/docs/hstaxe/description.rst
@@ -290,7 +290,7 @@ out on both the science and the master sky image.
 
 When reducing a dataset consisting of many individual exposures, it may
 be desirable to check the sky subtraction by co-adding all the sky-subtracted
-grism images (e.g. with the Astrodrizzle task). The co-added image also provides
+grism images (e.g., with the Astrodrizzle task). The co-added image also provides
 a way to quickly assess the quality of the background subtraction. Any deviations
 from zero in the mean background level of the combined image will also affect the
 spectra derived withthe aXe reduction.
@@ -473,7 +473,7 @@ with every grism image. A fluxcube file is a multi-dimensional fits
 image with one or several flux images taken at different wavelengths as
 extensions. The basis of the flux images are normal 2D images in
 :math:`[counts/sec]`, which must be transformed to flux in
-:math:`[erg/cm^2/s/Ã…Â]` using the appropriate zeropoints. All
+:math:`[erg/cm^2/s/\AA]` using the appropriate zeropoints. All
 extensions of the fluxcube image must cover the same area as the
 corresponding grism image.
 

--- a/docs/hstaxe/file_formats.rst
+++ b/docs/hstaxe/file_formats.rst
@@ -159,7 +159,7 @@ a WFC data set.
 Input Object List
 -----------------
 
-:ref:`sex` This file is a simple ASCII file containing tabulated information
+``sex``: This file is a simple ASCII file containing tabulated information
 about objects to be extracted. It has the same format as a SExtractor
 2.x output object catalog. The first few lines contain the name and
 description of each of the columns in the tabulated portion of this
@@ -240,7 +240,7 @@ sex2gol. It has exactly the same format as the Input Object List.
 Aperture File
 -------------
 
-:ref:`aper` This Aperture File is an ASCII file describing the APERTUREs in
+``aper``: This Aperture File is an ASCII file describing the APERTUREs in
 the spectroscopic image. An APERTURE consists of all BEAMS of an object.
 A BEAM is defined as the group of pixels in the image which will be
 extracted and combined to produce a final 1-D spectrum. APERTUREs are

--- a/docs/hstaxe/support.rst
+++ b/docs/hstaxe/support.rst
@@ -5,7 +5,7 @@ Support
 ===========================
 
 History
----------------
+-------
 The Space Telescope - European Coordinating Facility (STECF)
 was responsible for supporting the slitless spectroscopic modes
 of the Hubble instruments ACS and WFC3 until 2011

--- a/docs/hstaxe/using_axe.rst
+++ b/docs/hstaxe/using_axe.rst
@@ -39,7 +39,9 @@ The dispersed images observed with the G800L grism are:
 The data set presented here is in the HST archive. It has been taken as
 part of the ACS/HRC Parallels program to the ACS Ultra Deep Field.
 Moreover these images are also part of the test data for grism
-observations (see :ref:`validating_the_axe_install`).
+observations.
+
+.. (see :ref:`validating_the_axe_install`)
 
 
 .. warning:: Spectral extraction from MultiDrizzled grism/prism images:
@@ -130,8 +132,8 @@ hand increase the computation time and simulate contributions to the
 contamination of real objects.
 
 The master catalogue must contain all columns which are necessary for
-the spectral extraction with aXe (see the format description in
-�). The first few lines of the master catalogue
+the spectral extraction with aXe (see the format description).
+The first few lines of the master catalogue
 **f555w\_drz.cat** extracted from the direct image in
 :num:`figure #drizz-images` are:
 
@@ -499,8 +501,6 @@ it might be convenient to modify some keywords (see
 Chapt. [time\ :sub:`r`\ equirements]). The location of the configuration
 and calibration files is the directory indicated by the environment
 variable AXE\_CONFIG\_PATH (see Chapt. [Env Var]).
-
-[] |image|
 
 The ACS Wide Field Camera and the WFC3 UVIS Camera contain two CCD
 chips, and the data is stored in two independent extensions of the fits

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,12 +23,3 @@ Welcome to the hstaxe package documentation!
     File Formats <hstaxe/file_formats.rst>
     Appendix <hstaxe/appendix.rst>
     Bibliography <hstaxe/bibliography.rst>
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx-automodapi
+sphinx-rtd-theme
+stsci-rtd-theme


### PR DESCRIPTION
Supersedes #34 if you do not care about API doc and just wants to render the RST files.

I cannot turn RTD warnings into failures because there are some warnings that I do not immediately know how to get rid of and do not have time to do it:

```
.../docs/hstaxe/bibliography.rst:8: WARNING: Citation [BERTIN] is not referenced.
.../docs/hstaxe/bibliography.rst:12: WARNING: Citation [FRUCHTER] is not referenced.
.../docs/hstaxe/bibliography.rst:18: WARNING: Citation [KUMMEL1] is not referenced.
.../docs/hstaxe/bibliography.rst:22: WARNING: Citation [KUMMEL3] is not referenced.
.../docs/hstaxe/bibliography.rst:26: WARNING: Citation [KUMMEL5] is not referenced.
.../docs/hstaxe/bibliography.rst:30: WARNING: Citation [LARSON1] is not referenced.
.../docs/hstaxe/bibliography.rst:32: WARNING: Citation [LARSON2] is not referenced.
.../docs/hstaxe/bibliography.rst:38: WARNING: Citation [ROBERTSON] is not referenced.
.../docs/hstaxe/bibliography.rst:42: WARNING: Citation [vanDOKKUM] is not referenced.
.../docs/hstaxe/bibliography.rst:44: WARNING: Citation [WALSH] is not referenced.
...
WARNING: LaTeX command 'latex' cannot be run (needed for math display), check the imgmath_latex setting
...
build succeeded, 11 warnings.
```

The goal of this PR is just to have something build successfully on RTD. I did not vet the contents nor make sure the formatting looks pretty.

Rendered doc: https://hstaxe--37.org.readthedocs.build/en/37/