### PR TITLE
Allow interp flag of 0 in input checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 version 1.x.x (unreleased)
 --------------------------
-- no changes yet
+
+Bug Fixes
+^^^^^^^^^
+
+- Input checks now properly allow interp 0. [#39]
 
 version 1.0.1 (2021-01-10)
 --------------------------

--- a/hstaxe/axesrc/inputchecks.py
+++ b/hstaxe/axesrc/inputchecks.py
@@ -286,7 +286,7 @@ class InputChecker:
 
         # for background extraction the interpolation
         # type must be set
-        if back and not interp:
+        if back and interp is None:
             err_msg = ("{0:s}: The parameter 'interp' must be set for the "
                        "background PETs!".format(self.taskname))
             raise aXeError(err_msg)


### PR DESCRIPTION
Closes #38. Previously the check would fail on values of `None` and `0` when `0` should actually be an acceptable flag value (corresponding to average interpolation). 