### PR TITLE
Disable sensitivity adjustment for UVIS rather than failing silently

### DIFF
--- a/docs/hstaxe/axe_tasks.rst
+++ b/docs/hstaxe/axe_tasks.rst
@@ -354,7 +354,8 @@ Parameters
 
     weights:  compute and apply optimal weights
 
-    adj_sens: adjust the sensitivity function for extended sources
+    adj_sens: adjust the sensitivity function for extended sources. Note that
+              this option is not available for UVIS.
 
     sampling: the sampling mode for the stamp images
 
@@ -1092,6 +1093,10 @@ background subtraction is performed. Care must be taken that both Object
 and Background Pixel Extraction Tables were created with the same
 Aperture File. Additionally, absolute flux calibration can be performed
 if the proper information is included in the Main Configuration File.
+
+Note that the adj_sens parameter defaults to True for ACS and IR grims,
+but will be set to False for UVIS as this functionality is currently
+unavailable for UVIS.
 
 Usage
 ~~~~~

--- a/docs/hstaxe/axe_tasks.rst
+++ b/docs/hstaxe/axe_tasks.rst
@@ -1094,7 +1094,7 @@ and Background Pixel Extraction Tables were created with the same
 Aperture File. Additionally, absolute flux calibration can be performed
 if the proper information is included in the Main Configuration File.
 
-Note that the adj_sens parameter defaults to True for ACS and IR grims,
+Note that the adj_sens parameter defaults to True for ACS and IR grisms,
 but will be set to False for UVIS as this functionality is currently
 unavailable for UVIS.
 

--- a/hstaxe/axesrc/axetasks.py
+++ b/hstaxe/axesrc/axetasks.py
@@ -883,8 +883,8 @@ def pet2spc(grism='',
 
     if "UVIS" in config:
         adj_sens = False
-        print("\nWarning: extended source sensitivity adjustment is not available "
-              "for UVIS, setting adj_sens to False.")
+        _log.warn("\nWarning: extended source sensitivity adjustment is not available "
+                  "for UVIS, setting adj_sens to False.")
 
     pet2spc = axelowlev.aXe_PET2SPC(grism, config,
                                     use_bpet=use_bpet,

--- a/hstaxe/axesrc/axetasks.py
+++ b/hstaxe/axesrc/axetasks.py
@@ -312,7 +312,8 @@ def axecore(inlist='',
       compute and apply optimal weights
 
     adj_sens: bool
-       adjust the sensitivity function for extended sources
+       Adjust the sensitivity function for extended sources. 
+       Currently unavailable for UVIS.
 
     sampling: str
       the sampling mode for the stamp images
@@ -879,6 +880,11 @@ def pet2spc(grism='',
     """Function for the aXe task PET2SPC"""
     # check for required environment variables
     axe_setup()
+
+    if "UVIS" in config:
+        adj_sens = False
+        print("\nWarning: extended source sensitivity adjustment is not available "
+              "for UVIS, setting adj_sens to False.")
 
     pet2spc = axelowlev.aXe_PET2SPC(grism, config,
                                     use_bpet=use_bpet,


### PR DESCRIPTION
Previously, this would fail with an error that was stored in the logs but was not raised to the python user, leaving the output extracted spectrum files mysteriously empty for UVIS. Now this will log a warning (which gets displayed to the user in Jupyter) if `adj_sens` was `True` (the default) telling the user that the option is not available if a UVIS config is being used, and then proceed with the rest of the extraction after setting it to `False`.