### PR TITLE
update README option 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Clone the `hstaxe` software from this repository:
 Install `hstaxe` (and its dependencies):
 
     cd hstaxe
-    pip install .
+    pip install -e .
 
 
 ## Notebooks and Examples


### PR DESCRIPTION
It was determined that the `pip install` command should include the `-e` flag so that users can install a project in editable mode from a local project path.