### PR TITLE
Revert to astroconda wcstools for PyPI v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ incompatible with python versions greater than 3.9:
     conda create --name hstaxe_test python=3.9 -y
     conda activate hstaxe_test
     conda install gsl cfitsio make automake autoconf libtool pkg-config -y
-    conda install wcstools -c conda-forge -y
+    conda install wcstools -c https://ssb.stsci.edu/astroconda -y
     pip install hstaxe
 
 Optionally install Jupyter:


### PR DESCRIPTION
We'll need a new PyPI release before switching to `wcstools` from `conda-forge`. 

The installation docs for the dev version use the `conda-forge` version and will work after #46 is merged.