### PR TITLE
Make configure options fully automatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ __pycache__
 *.c
 
 # Other generated files
+*/_version.py
 */version.py
 */cython_version.py
 htmlcov

--- a/cextern/configure.ac
+++ b/cextern/configure.ac
@@ -18,6 +18,7 @@ AM_INIT_AUTOMAKE(foreign)
 # Checks for programs.
 AC_PROG_CC
 AC_CANONICAL_HOST
+PKG_PROG_PKG_CONFIG
 
 # libtools init and update
 LT_PREREQ([2.4.2])
@@ -67,10 +68,19 @@ AS_IF([test "x$with_cfitsio" != "xno"], [
        CFITSIO="$withval"
        ])
 
-AC_ARG_WITH(wcstools, [AS_HELP_STRING([--with-wcstools], [path to wcstools])])
-AS_IF([test "x$with_wcstools" != "xno"], [
-       WCSTOOLS="$withval"
-       ])
+AC_ARG_WITH(wcstools,
+    [AS_HELP_STRING([--with-wcstools],
+                    [path to wcstools])],
+    [use_wcstools=$withval],
+    [use_wcstools=no])
+
+
+AC_ARG_WITH([wcstools-libname],
+    [AS_HELP_STRING([--with-wcstools-libname],
+                    [set wcstools library name])],
+    [WCSTOOLS_LIBNAME=$withval],
+    [WCSTOOLS_LIBNAME=wcs])
+
 
 AC_ARG_WITH(wcstools-libname, [AS_HELP_STRING([--with-wcstools-libname], [path to wcstools])])
 AS_IF([test "x$with_wcstools_libname" != "xno"], [
@@ -91,20 +101,23 @@ else
     PKG_CHECK_MODULES([CFITSIO], [cfitsio >= 3])
 fi
 
-if test "x$WCSTOOLS_LIBNAME" == "x"; then
-    WCSTOOLS_LIBNAME="wcs"
-fi
-
-if test "x$WCSTOOLS" != "x"; then
+if test "x$use_wcstools" == "xno"; then
+    AC_MSG_NOTICE([using wcstools from... pkg-config])
+    PKG_CHECK_MODULES([WCSTOOLS], [wcstools >= 3.9],
+        [
+            if $PKG_CONFIG --libs wcstools | grep 'lwcstools' >/dev/null; then
+                WCSTOOLS_LIBNAME=wcstools
+            fi
+        ])
+else
+    AC_MSG_NOTICE([using wcstools from... user-defined])
     incdir="$WCSTOOLS/include"
     WCSTOOLS_LIBS="-L$WCSTOOLS/lib -l${WCSTOOLS_LIBNAME} -lm"
     WCSTOOLS_CFLAGS="-I$incdir -I$incdir/${WCSTOOLS_LIBNAME}"
-    LDFLAGS="$LDFLAGS $WCSTOOLS_LIBS"
-    CFLAGS="$CFLAGS $WCSTOOLS_CFLAGS"
-else
-    PKG_CHECK_MODULES([WCSTOOLS], [wcstools >= 3.9])
 fi
 
+LDFLAGS="$LDFLAGS $WCSTOOLS_LIBS"
+CFLAGS="$CFLAGS $WCSTOOLS_CFLAGS"
 
 # Checks for header files.
 AC_CHECK_HEADERS([limits.h math.h stddef.h stdlib.h string.h unistd.h])
@@ -117,6 +130,27 @@ AC_CHECK_HEADER_STDBOOL
 AC_FUNC_MALLOC
 AC_FUNC_STRTOD
 AC_CHECK_FUNCS([floor pow rint sqrt strchr strdup strstr strtol])
+
+cat << EOF
+
+hstaxe has been configured with the following
+
+Host:                ${host}
+Compiler:            ${CC}
+Preprocessor flags:  ${CPPFLAGS}
+Compiler flags:      ${CFLAGS}
+Preprocessor flags:  ${CPPFLAGS}
+Linker flags:        ${LDFLAGS}
+
+CFITSIO_CFLAGS:   $CFITSIO_CFLAGS
+CFITSIO_LIBS:     $CFITSIO_LIBS
+GSL_CFLAGS:       $GSL_CFLAGS
+GSL_LIBS:         $GSL_LIBS
+WCSTOOLS_CFLAGS:  $WCSTOOLS_CFLAGS
+WCSTOOLS_LIBNAME: $WCSTOOLS_LIBNAME
+WCSTOOLS_LIBS:    $WCSTOOLS_LIBS
+
+EOF
 
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -165,12 +165,13 @@ def BuildExtWithConfigure():
             # otherwise this must be a vanilla wcstools from upstream
             # with "libwcs", and no .pc file
             CONFIGURE_ARGS += ["--with-wcstools-libname=wcs"]
-
-    if WCSTOOLS_SEARCH_PATH:
+    else:
         # pkg-config is installed
-        # prepend the search path
-        PKG_CONFIG_PATH.insert(0, WCSTOOLS_SEARCH_PATH)
+        if WCSTOOLS_SEARCH_PATH:
+            # prepend the search path
+            PKG_CONFIG_PATH.insert(0, WCSTOOLS_SEARCH_PATH)
 
+    # apply the search path to the environment
     os.environ["PKG_CONFIG_PATH"] = ":".join(PKG_CONFIG_PATH)
     try:
         check_call(["sh", "autogen.sh"],

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -5,6 +5,7 @@
 #
 #
 import sys
+import sysconfig
 import os
 import pathlib
 
@@ -18,6 +19,85 @@ if (sys.version_info < (3, 7)):
 
 AXELIB_DIR = "cextern/"
 CONF_H_NAME = os.path.join(AXELIB_DIR, "config.h")
+
+
+def find_program(name):
+    paths = os.environ.get("PATH")
+    if not paths:
+        raise EnvironmentError("PATH is not set")
+
+    for path in paths.split(":"):
+        if not os.path.exists(path):
+            continue
+        for program in os.listdir(path):
+            program_path = os.path.join(path, program)
+            if name == program:
+                return program_path
+    return ""
+
+
+def check_pkgconfig(name):
+    pkg_configs = []
+    ext = ".pc"
+    target = name
+    result = {
+        "usable": False,
+        "search_path": "",
+        "file": "",
+    }
+
+    # Append file extension to target if not present
+    if not target.endswith(ext):
+        target += ext
+
+    # Determine where pkg-config lives and generate a search path
+    pkg_config_prefix = os.path.dirname(os.path.dirname(find_program("pkg-config")))
+    if pkg_config_prefix:
+        result["usable"] = True
+        pkg_configs += [os.path.join(pkg_config_prefix, "lib64", "pkgconfig")]
+        pkg_configs += [os.path.join(pkg_config_prefix, "lib", "pkgconfig")]
+        pkg_configs += [os.path.join(pkg_config_prefix, "share", "pkgconfig")]
+
+    # pkg-config might not be local to Python's runtime environment
+    # Generate a search path for it as well
+    if sys.prefix != pkg_config_prefix:
+        pkg_configs += [os.path.join(sys.prefix, "lib64", "pkgconfig")]
+        pkg_configs += [os.path.join(sys.prefix, "lib", "pkgconfig")]
+        pkg_configs += [os.path.join(sys.prefix, "share", "pkgconfig")]
+        
+    # Consume user defined pkg-config search path
+    pkg_configs_user = os.environ.get("PKG_CONFIG_PATH", "")
+    if pkg_configs_user:
+        pkg_configs = [*pkg_configs_user.split(":"), pkg_configs]
+
+    # Is the target file present in any of the search paths?
+    for path in pkg_configs:
+        if result["file"]:
+            # the previous iteration found something
+            break
+
+        if not os.path.exists(path):
+            continue
+
+        for config in os.listdir(path):
+            config_path = os.path.join(path, config)
+            if config == target:
+                result["file"] = config_path
+                # only store where we found the file. let the caller
+                # handle PKG_CONFIG_PATH modifications
+                result["search_path"] = os.path.dirname(config_path)
+                break
+
+    return result
+
+
+def find_in_file(filename, s):
+    with open(filename, "r") as fp:
+        for line in fp.read().splitlines():
+            if s in line:
+                return line
+        return ""
+
 
 def clean_executables():
     current_env = sys.prefix + "/bin/"
@@ -56,23 +136,54 @@ def clean_executables():
     if os.access(CONF_H_NAME, os.F_OK):
         os.remove(CONF_H_NAME)
 
+
 def BuildExtWithConfigure():
     CURRENT_ENV = sys.prefix
+    CONFIGURE_ARGS = ["--prefix="+CURRENT_ENV,
+                      "--with-cfitsio="+CURRENT_ENV,
+                      "--with-gsl="+CURRENT_ENV,
+                      "--libdir="+sysconfig.get_config_var("LIBDIR")]
+
+    PKG_CONFIG_PATH = []
+    if os.environ.get("PKG_CONFIG_PATH", ""):
+        PKG_CONFIG_PATH = PKG_CONFIG_PATH.split(":")
+
+    WCSTOOLS = check_pkgconfig("wcstools")
+    WCSTOOLS_USABLE = WCSTOOLS["usable"]
+    WCSTOOLS_FILE = WCSTOOLS["file"]
+    WCSTOOLS_SEARCH_PATH = WCSTOOLS["search_path"]
+
+    if not WCSTOOLS_USABLE:
+        # pkg-config is not installed
+        # configure options manually
+        CONFIGURE_ARGS += ["--with-wcstools="+CURRENT_ENV]
+
+        if WCSTOOLS_FILE and find_in_file(WCSTOOLS_FILE, "-lwcstools"):
+            # we *do* have a .pc that wants libwcstools
+            CONFIGURE_ARGS += ["--with-wcstools-libname=wcstools"]
+        else:
+            # otherwise this must be a vanilla wcstools from upstream
+            # with "libwcs", and no .pc file
+            CONFIGURE_ARGS += ["--with-wcstools-libname=wcs"]
+
+    if WCSTOOLS_SEARCH_PATH:
+        # pkg-config is installed
+        # prepend the search path
+        PKG_CONFIG_PATH.insert(0, WCSTOOLS_SEARCH_PATH)
+
+    os.environ["PKG_CONFIG_PATH"] = ":".join(PKG_CONFIG_PATH)
     try:
         check_call(["sh", "autogen.sh"],
                    cwd=AXELIB_DIR)
         check_call(["sh", "./configure",
-                    "--with-cfitsio="+CURRENT_ENV,
-                    "--with-wcstools="+CURRENT_ENV,
-                    "--with-gsl="+CURRENT_ENV,
-                    "--libdir="+CURRENT_ENV,
-                    "--prefix="+CURRENT_ENV],
+                    *CONFIGURE_ARGS],
                    cwd=AXELIB_DIR)
         check_call(["make", "clean"], cwd=AXELIB_DIR)
         check_call(["make", "install"], cwd=AXELIB_DIR)
     except CalledProcessError as e:
         print(e)
         exit(1)
+
 
 class CustomBuildHook(BuildHookInterface):
     """Configure, build, and install the aXe C code."""

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -68,7 +68,7 @@ def check_pkgconfig(name):
     # Consume user defined pkg-config search path
     pkg_configs_user = os.environ.get("PKG_CONFIG_PATH", "")
     if pkg_configs_user:
-        pkg_configs = [*pkg_configs_user.split(":"), pkg_configs]
+        pkg_configs = [*pkg_configs_user.split(":"), *pkg_configs]
 
     # Is the target file present in any of the search paths?
     for path in pkg_configs:
@@ -146,7 +146,7 @@ def BuildExtWithConfigure():
 
     PKG_CONFIG_PATH = []
     if os.environ.get("PKG_CONFIG_PATH", ""):
-        PKG_CONFIG_PATH = PKG_CONFIG_PATH.split(":")
+        PKG_CONFIG_PATH = os.environ["PKG_CONFIG_PATH"].split(":")
 
     WCSTOOLS = check_pkgconfig("wcstools")
     WCSTOOLS_USABLE = WCSTOOLS["usable"]


### PR DESCRIPTION
#45 didn't feel finished to me. Here's the rest of the implementation (and some bug fixes)

- If you want the configure script to use `pkg-config` don't issue the `--with-wcstools=` argument.
- If `pkg-config` is installed but `wcstools.pc` is missing, use the `--with-wcstools=` method, and assume the library is `-lwcs`
- If `pkg-config` is NOT installed but `wcstools.pc` exists, and the file contains `lwcstools`, use the `--with-wcstools=` method, and assume the library is `-lwcstools`
- Print a configuration summary to aid bug reporting