### PR TITLE
Update description of background subtraction and interp parameter

### DIFF
--- a/docs/hstaxe/axe_tasks.rst
+++ b/docs/hstaxe/axe_tasks.rst
@@ -165,7 +165,7 @@ is mandatory if axedrizzle is to be used later on.
 
 axeprep provides three different processing steps:
 
--  background subtraction:
+*  global background subtraction:
    Provided that an Input Object List is given for the grism image,
    axeprep uses the tasks sex2gol, gol2af and backest to mark the beam
    areas on the grism image as well as on the master background image.
@@ -175,10 +175,12 @@ axeprep provides three different processing steps:
    image. The master background, scaled to the level of the grism image,
    is finally subtracted from the grism image.
 
--  exposure time normalization The input file is normalized by the
+*  exposure time normalization:
+   The input file is normalized by the
    exposure time to transform the images into counts per second.
 
--  gain correction The input file is multiplied by the gain conversion
+*  gain correction:
+   The input file is multiplied by the gain conversion
    factor (electrons/ADU) to transform the images from units of detector
    counts to electrons. For HST data, this is usually only necessary for
    NICMOS images, because ACS and WFC3 images will normally already be
@@ -249,7 +251,7 @@ AXECORE
 [AXECORE] This aXe task combines the Low Level Tasks sex2gol, gol2af,
 af2pet, petff, petcont, pet2spc and stamps and offers the possibility to
 make a complete aXe reduction based on the individual images in one
-task. This also includes the reduction with background PETs (set
+task. This also includes local background subtraction (set
 back=YES). The parameter list comprises all parameters for the
 individual tasks, and as a consequence is rather long. For most of the
 parameters the default value is appropriate, so the actual number of
@@ -281,6 +283,8 @@ Usage
 ::
 
     axecore inlist configs extrfwhm drzfwhm back backfwhm orient slitless_geom exclude ...
+
+.. _axecore_parameters:
 
 Parameters
 ~~~~~~~~~~

--- a/docs/hstaxe/axe_tasks.rst
+++ b/docs/hstaxe/axe_tasks.rst
@@ -333,8 +333,7 @@ Parameters
     np:       number of points for background estimation
 
     interp:   interpolation type for background determination
-              (-1: GLOBAL median; 0: local median; 1: linear fit;
-              2: quadratic fit)
+              (-1: median; 0: average; 1: linear fit; 2: quadratic fit)
 
     niter_med: number of kappa-sigma iterations around the median
 
@@ -806,6 +805,8 @@ If  back='NO':
 If  back='YES':
 
 -  $AXE\_OUTPUT\_PATH/[slitless filename]\_[ext number].BAF
+
+.. _backest_task:
 
 BACKEST
 -------

--- a/docs/hstaxe/description.rst
+++ b/docs/hstaxe/description.rst
@@ -257,7 +257,7 @@ set ``backgr`` to ``False`` in the ``axeprep`` step::
 The strategy of estimating a local sky background can also be applied
 after a global sky background subtraction for very difficult cases or
 instruments (e.g. NICMOS G141 data, see [FREUDLING]_ ). In either case (with
-or without previous global sky background subtraction), the local bckground
+or without previous global sky background subtraction), the local background
 subtraction is used by setting ``back=False`` and specifying a value for
 ``backfwhm``, ``np``, and ``interp`` in the ``axetasks.axecore`` step, for
 example::

--- a/docs/hstaxe/description.rst
+++ b/docs/hstaxe/description.rst
@@ -258,7 +258,7 @@ The strategy of estimating a local sky background can also be applied
 after a global sky background subtraction for very difficult cases or
 instruments (e.g. NICMOS G141 data, see [FREUDLING]_ ). In either case (with
 or without previous global sky background subtraction), the local background
-subtraction is used by setting ``back=False`` and specifying a value for
+subtraction is used by setting ``back=True`` and specifying a value for
 ``backfwhm``, ``np``, and ``interp`` in the ``axetasks.axecore`` step, for
 example::
 

--- a/docs/hstaxe/description.rst
+++ b/docs/hstaxe/description.rst
@@ -232,17 +232,51 @@ master-sky frame from each input spectrum image at the beginning of
 the reduction process. This removes the background signature from the
 images, so that the remaining signal can be assumed to originate from
 the sources only and is extracted without further background correction
-in the aXe reduction.
+in the aXe reduction. To enable global background subtraction in ``hstaxe``,
+set the ``backgr`` argument in the ``axeprep`` step to ``True``, for example::
+
+    axetasks.axeprep(inlist="aXe.lis",
+                     configs="G141.F140W.V4.31.conf",
+                     backgr=True,
+                     norm=False,
+                     mfwhm=3.0)
 
 The second strategy is to make a local estimate of the sky background
 for each BEAM by interpolating between the adjacent pixels on either
 side of the BEAM. In this case, an individual sky estimate is made for
-every BEAM in each science image.
+every BEAM in each science image. Counter-intuitively, if you wish to
+do local subtraction without doing a global subtraction first, you must
+set ``backgr`` to ``False`` in the ``axeprep`` step::
+
+    axetasks.axeprep(inlist="aXe.lis",
+                     configs="G141.F140W.V4.31.conf",
+                     backgr=False,
+                     norm=False,
+                     mfwhm=3.0)
 
 The strategy of estimating a local sky background can also be applied
 after a global sky background subtraction for very difficult cases or
-instruments (e.g. NICMOS G141 data, see [FREUDLING]_ ).
+instruments (e.g. NICMOS G141 data, see [FREUDLING]_ ). In either case (with
+or without previous global sky background subtraction), the local bckground
+subtraction is used by setting ``back=False`` and specifying a value for
+``backfwhm``, ``np``, and ``interp`` in the ``axetasks.axecore`` step, for
+example::
 
+    axetasks.axecore('aXe.lis',
+                     "G141.F140W.V4.31.conf",
+                     np=5,
+                     interp=0,
+                     back=True,
+                     backfwhm=4.0,
+                     [additional keyword arguments])
+
+For additional information about these parameters, see :ref:`axecore_parameters`
+and :ref:`backest_task`. More information about local and global background
+subtraction is also given below.
+
+In addition to global and local background subtraction, you can choose to
+not perform any sky background subtraction at all by setting ``backgr=False``
+in the ``axeprep`` step and ``back=False`` in the ``axecore`` step.
 
 .. _global_background_subtraction:
 
@@ -280,7 +314,6 @@ spectra derived withthe aXe reduction.
 
 Local Background Subtraction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 
 The second option for handling the sky background is to make a local
 estimate of the background for each object. In this case, aXe creates an

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,9 +20,16 @@ employed under Linux, Solaris, and MacOS X.
 
 HSTaXe is the successor to aXe, a similar package written on PyRAF/IRAF.
 
-.. note::
+.. warning::
    This documentation mostly overlaps with, but is not identical to, the original
-   aXe manual. The last version of the aXe manual can be downloaded from
+   aXe manual. This means that many of the descriptions and code snippets provided
+   refer to the old command line/IRAF-based version of aXe rather than the current
+   python-based ``hstaxe``. The installation and example notebooks sections, as well
+   as some content related to background subtraction, has been more recently updated
+   to be up-to-date for ``hstaxe``. The rest of the older content is nonetheless
+   useful for understanding what is going on "under the hood".
+
+   The last version of the aXe manual can be downloaded from
    `the hstaxe repository <https://github.com/spacetelescope/hstaxe/tree/main/docs/aXe_manual/axe-user-manual-v-2-3.pdf>`_.
 
 Attribution

--- a/hstaxe/axesrc/axetasks.py
+++ b/hstaxe/axesrc/axetasks.py
@@ -285,7 +285,7 @@ def axecore(inlist='',
 
     interp: int
       interpolation type for background determination
-      (-1: GLOBAL median; 0: local median; 1: linear fit;
+      (-1: median; 0: average; 1: linear fit;
       2: quadratic fit)
 
     niter_med: int


### PR DESCRIPTION
Gives some more detail and example about how to run local/global/no background subtraction in the relevant parts of section 3, and corrects the specification of the `interp` parameter throughout.