### PR TITLE
Streamlining basic IR workflow and change example data to G102

### DIFF
--- a/cookbooks/wfc3-basic-ir-hstaxe-cookbook.ipynb
+++ b/cookbooks/wfc3-basic-ir-hstaxe-cookbook.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d5ca3109",
    "metadata": {},
@@ -21,35 +22,38 @@
     "\n",
     "## Table of Contents\n",
     "\n",
-    "[Introduction](#intro) <br>\n",
-    "[1. Imports](#import) <br>\n",
-    "[2. Setup](#setup) <br>\n",
-    "- [2.1 Drizzling Input Data](#drizzle) <br>\n",
-    "- [2.2 Creating a Catalog with SExtractor](#catalog) <br>\n",
-    "\n",
-    "[3. Running HSTaXe](#axe) <br>\n",
-    "- [3.1. Outputs](#out) <br>\n",
-    "\n",
-    "[4. Conclusions](#conclusions) <br>\n",
-    "[About this Notebook](#about) <br>\n",
-    "[Citations](#cite) <br>"
+    "[Introduction](#intro)<br>\n",
+    "[1. Imports](#import)<br>\n",
+    "[2. Setup](#setup)<br>\n",
+    "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[2.1 Drizzling Input Data](#drizzle)<br>\n",
+    "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[2.2 Creating a Catalog with SExtractor](#catalog)<br>\n",
+    "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[2.3 Copy Catalog and Rename Mag Column](#copycat)<br>\n",
+    "[3. Running HSTaXe](#axe)<br>\n",
+    "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[3.1. Outputs](#out) <br>\n",
+    "[4. Conclusions](#conclusions)<br>\n",
+    "[About this Notebook](#about)<br>\n",
+    "[Citations](#cite)<br>"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2407f8e9",
    "metadata": {},
    "source": [
-    "## Introduction <a id=\"intro\"></a>\n",
+    "# Introduction <a id=\"intro\"></a>\n",
     "\n",
-    "[HSTaXe](https://hstaxe.readthedocs.io/en/latest/index.html) is a Python package that provides spectral extraction processes for HST data. Please ensure that you have installed the `hstaxe` module according to the instructions in the documentation, and are running this notebook from the environment created through those instructions.\n",
+    "[HSTaXe](https://hstaxe.readthedocs.io/en/latest/index.html) is a Python package that provides spectral extraction processes for HST data. **Please be aware that running this notebook requires creating a conda environment from the provided `.yml` file in this notebook's [github repository](https://github.com/spacetelescope/hstaxe/tree/main/cookbooks).** For more details about creating the necessary environment see the notebook's README file.\n",
     "\n",
-    "This notebook will take you through a basic extraction using WFC3/IR grism data. Example data using the G141 grism are available [here](https://stsci.box.com/s/j2ygj4gaqgzmp0b4xcc1h2rszz6cv9wm) if you would like to practice the workflow. You can dowload all required data in the `example_data` subdirectory, and store it within the same parent directory as this notebook.\n",
+    "Below, we show the workflow for a basic specral extraction using WFC3/IR G102 grism data. **The example data we use in this notebook are available [here](https://stsci.box.com/s/j2ygj4gaqgzmp0b4xcc1h2rszz6cv9wm).** If you would like to use this notebook with the example data, please download the `example_data` subdirectory from the link above, and store it within the same parent directory as this notebook. Once you have the example data directory, this notebook is intended to run continuously without needing to edit any of the cells. \n",
     "\n",
-    "This notebook will also require configuration files for HSTaXe, which can be downloaded [here](https://stsci.box.com/s/vzkf9x6fmnkjxq6q3v1gbuggk4y3r7kx). These files should then be stored in the `CONF` subdirectory that will be created later in the notebook."
+    "In addition to the grism and direct image data, **this notebook also requires configuration files for HSTaXe, which can be downloaded [here](https://stsci.box.com/s/1tl1iq230yenip94hbt4pfz1mggkkp2i).** The `config_files` directory should be stored in the  same parent directory as this notebook, and later we will be copy them to the `CONF` subdirectory created by HSTaXe.\n",
+    "\n",
+    "**If you plan to use your own data with this notebook, please be aware you will be required to create an input source catalog with SExtractor.** Information regarding SExtractor including installation instructions are available [here](https://sextractor.readthedocs.io/en/latest/Installing.html). In addition to installing SExtractor, you must run the software with aXe specific configuration files. **These aXe-SExtractor configuration files can be downloaded [here](https://stsci.box.com/s/3npry36gu7ocfnuxgzwr5syj4i8r7hy8).** Once SExtractor is installed, create a `sextractor` directory in the same parent directory as this notebook, and place configuration files inside. "
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a91e02da",
    "metadata": {},
@@ -61,11 +65,11 @@
     "- *os*, *glob* and *shutil*, for file handling\n",
     "- *numpy* for array handling\n",
     "- *astropy.io.fits* for FITS file handling\n",
+    "- *astropy.table.Table* for table functions\n",
+    "- *ginga.util.zscale* for image display scaling\n",
     "- *matplotlib.pyplot* for plotting\n",
     "- *astrodrizzle* for creating input image mosaics\n",
-    "- *hstaxe.axetasks* for performing the spectral extraction\n",
-    "\n",
-    "This notebook will also require a working installation of SExtractor, which will be used to create an input catalog for HSTaXe. Instructions for installing SExtractor are available [here](https://sextractor.readthedocs.io/en/latest/Installing.html)."
+    "- *hstaxe.axetasks* for performing the spectral extraction"
    ]
   },
   {
@@ -81,9 +85,10 @@
     "import shutil\n",
     "import glob\n",
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
     "from astropy.io import fits, ascii\n",
     "from astropy.table import Table\n",
+    "import matplotlib.pyplot as plt\n",
+    "from ginga.util import zscale\n",
     "from drizzlepac import astrodrizzle\n",
     "from hstaxe import axetasks"
    ]
@@ -179,7 +184,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Creat list file using images in grism directory\n",
+    "# Create list file using images in grism directory\n",
     "os.chdir('grism_ims')\n",
     "\n",
     "lis = open('grism.lis', 'w')\n",
@@ -200,6 +205,7 @@
    "outputs": [],
    "source": [
     "# Drizzle grism images. If only using one input image, set blot, median, driz_cr to False\n",
+    "# If your input images were flc images rather than flt images, change the extension to 'drc.fits'\n",
     "astrodrizzle.AstroDrizzle('@grism.lis', output='grism', \n",
     "                          build=True, blot=True, median=True, driz_cr=True)"
    ]
@@ -260,79 +266,79 @@
    "outputs": [],
    "source": [
     "os.chdir(cwd)\n",
-    "fig, axs = plt.subplots(1, 2, figsize=(8,8))\n",
+    "fig, axs = plt.subplots(1, 2, figsize=(10,10), dpi=200)\n",
     "\n",
     "d = fits.getdata('direct_ims/direct_drz.fits', 1)\n",
-    "im1 = axs[0].imshow(d, origin='lower')\n",
+    "z1,z2 = zscale.zscale(d)\n",
+    "im1 = axs[0].imshow(d, origin='lower', cmap='Greys_r', vmin=z1, vmax=z2)\n",
+    "axs[0].set_title('direct_drz.fits')\n",
+    "fig.colorbar(im1,shrink=0.4,pad=0.01)\n",
     "\n",
     "d = fits.getdata('grism_ims/grism_drz.fits', 1)\n",
-    "im2 = axs[1].imshow(d, origin='lower')\n",
-    "\n",
-    "# Adjust image levels here\n",
-    "im1.set_clim(0, 0.2)\n",
-    "im2.set_clim(0, 0.2)\n",
+    "z1,z2 = zscale.zscale(d)\n",
+    "im2 = axs[1].imshow(d, origin='lower', cmap='Greys_r', vmin=z1, vmax=z2)\n",
+    "axs[1].set_title('grism_drz.fits')\n",
+    "fig.colorbar(im2,shrink=0.4,pad=0.01)\n",
     "\n",
     "plt.tight_layout()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "30810db8",
    "metadata": {},
    "source": [
-    "## 2.2 Creating a Catalog with SExtractor<a id=\"catalog\"></a>\n",
+    "## 2.2 Creating a Catalog with SExtractor <a id=\"catalog\"></a>\n",
     "\n",
-    "With our drizzle images created, we now need a catalog of sources in the direct image. Creating this catalog requires using SExtractor, which may need to be installed separately; please refer to the link in the Imports section for instructions on how to do this.\n",
+    "This section is intended for anyone using data other than the `example_data` provided for this notebook. Since we also provide a catalog in the `example_data` directory and will not formally run SExtractor here, we want to explain the process behind using the drizzle image to create a new catalog with SExtractor. **Please refer to the links in the [Introduction](#intro) section for instructions regarding installing SExtractor and downloading the necessary aXe-SExtractor configuration files.**\n",
     "\n",
-    "HSTaXe will look for a highly specific format in the catalog, and does not always give clear error messages when something within the catalog is awry. Please follow the next steps carefully:\n",
+    "HSTaXe will look for a highly specific format in the catalog, and does not always give clear error messages when something within the catalog is awry. If creating a catalog yourself, please follow the next steps carefully:\n",
     "\n",
-    "1. Copy the drizzled direct image into the `sextractor` directory, which contains HSTaXe-appropriate configuration files for SExtractor."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e9857159",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "shutil.copy('direct_ims/direct_drz.fits', 'sextractor/')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ad5532f4",
-   "metadata": {},
-   "source": [
-    "2. With SExtractor installed, run the following command from within the `sextractor` directory that came with this notebook:\n",
-    "    `sex -c aXe.sex direct_drz.fits[1] -DETECT_THRESH 5 -MAG_ZEROPOINT 26.4525`\n",
+    "1. Copy the drizzled direct image into the `sextractor` directory (once created), which contains HSTaXe-appropriate configuration files for SExtractor.\n",
     "\n",
-    "    Note that the value for the `DETECT_THRESH` keyword, which sets the minimum value for pixels to be considered, may be changed appropriately for your data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "88dd395f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<u>Example code:</u>\n",
+    "```python\n",
+    "shutil.copy('direct_ims/direct_drz.fits', 'sextractor/')\n",
+    "```\n",
+    "2. With SExtractor installed, run the follow\"ing command from within the `sextractor` directory that you created:\n",
+    "   \n",
+    "   `sex -c aXe.sex direct_drz.fits[1] -DETECT_THRESH 5 -MAG_ZEROPOINT 26.4525`\n",
+    "\n",
+    "    Note that the value for the `DETECT_THRESH` keyword, which sets the minimum value for pixels to be considered, may be changed appropriately for your data. `MAG_ZEROPOINT` should also be changed to match the magnitude zeropoint of the direct image filter for your data. A table is provided below containing the pivot wavelengths and zeropoints for the WFC3/IR grism reference filters.\n",
+    "    \n",
+    "| Filter \t| Pivot Wavelength (nm) \t| Zeropoint (ABmag) \t|\n",
+    "|--------\t|-----------------------\t|-------------------\t|\n",
+    "| F098M  \t| 986.4                 \t| 25.666            \t|\n",
+    "| F105W  \t| 1055                  \t| 26.264            \t|\n",
+    "| F140W  \t| 1392                  \t| 26.450            \t|\n",
+    "| F160W  \t| 1537                  \t| 25.936            \t|\n",
+    "\n",
+    "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<u>Example code:</u>\n",
+    "```python\n",
     "os.chdir('sextractor')\n",
+    "detect_thresh = 10\n",
+    "cl_input = f'sex -c aXe.sex direct_drz.fits[1] -DETECT_THRESH {detect_thresh} -MAG_ZEROPOINT 25.666'\n",
+    "os.system(cl_input)\n",
+    "``` \n",
+    "3. At this point you should have created a catalog. The next steps include copying the file into the `direct_ims` directory and editing the name of the `MAG_ISO` column. See [Section 2.3](#copycat) for information regarding renaming the `MAG_ISO` column. \n",
     "\n",
-    "detect_thresh = 5\n",
-    "cl_input = f'sex -c aXe.sex direct_drz.fits[1] -DETECT_THRESH {detect_thresh} -MAG_ZEROPOINT 26.4525'"
+    "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<u>Example code:</u>\n",
+    "```python\n",
+    "os.chdir(cwd)\n",
+    "shutil.copy('sextractor/aXe.cat', 'direct_ims')\n",
+    "```"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2f57cb43",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "ee9f377a",
+   "metadata": {},
    "source": [
-    "os.system(cl_input)"
+    "## 2.3 Copy Catalog and Rename Mag Column <a id=\"copycat\"></a>\n",
+    "\n",
+    "The catalog corresponding to the data used in this notebook is included in the `example_data` directory downloaded in the Introduction section. Start by copying the catalog into the `direct_ims` directory."
    ]
   },
   {
@@ -342,22 +348,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Copy the catalog to the direct image directory\n",
-    "os.chdir(cwd)\n",
-    "# shutil.copy('sextractor/aXe.cat', 'direct_ims')\n",
-    "\n",
     "# Copy the example catalog to the direct image directory:\n",
-    "shutil.copy('example_data/aXe.cat', 'direct_ims')"
+    "os.chdir(cwd)\n",
+    "shutil.copy('example_data/aXe.cat', 'direct_ims');"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0058a1c3",
    "metadata": {},
    "source": [
-    "3. Examine the catalog. The \"MAG_ISO\" column must be renamed to \"MAG_F####\" for it to be correctly read in by HSTaXe, with \"####\" being replaced by a number, nominally the pivot wavelength of the direct image filter in nm (e.g. 1392 for F140W). Any lines containing clearly spurious detections, such as those with magnitudes of $\\pm$99, should also be removed. **Note**: These edits must be done manually as astropy only supports reading of SExtractor-formatted tables, not writing.\n",
+    "Examine the catalog. The \"MAG_ISO\" column must be renamed to \"MAG_F####\" for the catalog to be correctly read in by HSTaXe. Where \"####\" is the pivot wavelength of the direct image filter in nm (Å for WFC3/UVIS, e.g. 4971 for F200LP and 1392 for F140W). Please see WFC3 Instrument Handbook Section 7.5 [\"IR Spectral Elements\"](https://hst-docs.stsci.edu/wfc3ihb/chapter-7-ir-imaging-with-wfc3/7-5-ir-spectral-elements) for information about UVIS filter pivot wavelengths. You can also refer to the table above as a quick-reference for the pivot wavelength of the recommended direct image filters for the IR grisms.\n",
     "\n",
-    "    Additionally, locate the lines containing the sources whose spectra you want to extract and note the line number from the NUMBER column. This will be used later to identify the BEAM number for your object in the output files."
+    "Any lines in the catalog containing clearly spurious detections, such as those with magnitudes of 99.0, should also be removed. **Note**: Removing spurious detections must be done manually.\n",
+    "\n",
+    "Lastly, locate the lines containing the sources whose spectra you want to extract and note the line number from the NUMBER column. This will be used later to identify the BEAM number for your object in the output files."
    ]
   },
   {
@@ -368,9 +374,66 @@
    "outputs": [],
    "source": [
     "cat = Table.read('direct_ims/aXe.cat', format='ascii.sextractor')\n",
-    "cat\n",
+    "cols_to_show = ['NUMBER', 'X_IMAGE', 'Y_IMAGE', 'A_IMAGE', 'B_IMAGE', 'MAG_ISO', 'MAGERR_ISO']\n",
+    "cat[cols_to_show].show_in_notebook()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "99ee9d2a",
+   "metadata": {},
+   "source": [
+    "To avoid having to edit the column information manually in the SExtractor catalog, there is a helper function below called `edit_catalog_pivot`. It takes in the SExtractor catalog, output file path/name, and the pivot wavelength value and edits the information and writes to the output file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3afd91c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def edit_catalog_pivot(inputfile, outputfile, pivot_wave):\n",
+    "    \"\"\" Function to edit the auto-generated sextractor header/column name so aXe will run\n",
+    "        \n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        inputfile : str\n",
+    "            The full path to the input catalog including filename\n",
+    "        outputfile : str\n",
+    "            The full path to the output catalog including filename\n",
+    "        pivot_wave : int or str\n",
+    "            The pivot wavelength of filter used in the driect image\n",
+    "            For UVIS please use 4 digits in units of Angstrom and \n",
+    "            for IR please use 4 ditits in units of nanometers \n",
+    "            \n",
+    "        Return\n",
+    "        ------\n",
+    "        Nothing. But a file is written to `outputfile`\n",
+    "    \"\"\"\n",
+    "    # Read in the input catalog\n",
+    "    with open(inputfile, 'r') as f:\n",
+    "        lines = f.readlines()\n",
     "\n",
-    "# Rename the MAG_ISO column and remove spurious rows manually!"
+    "    with open(outputfile, 'w') as f:\n",
+    "        # Find the mag_iso row and replace with pivot wavelength\n",
+    "        for line in lines:\n",
+    "            line = line.replace('MAG_ISO', f'MAG_F{pivot_wave}')\n",
+    "            f.write(line)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cde19974",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputfile = 'direct_ims/aXe.cat'\n",
+    "outputfile = 'direct_ims/aXe_ir_f098m.cat'\n",
+    "pivot_wave = 986 # nm\n",
+    "edit_catalog_pivot(inputfile, outputfile, pivot_wave)"
    ]
   },
   {
@@ -382,18 +445,21 @@
    "source": [
     "# Use this cell to filter your catalog for your sources\n",
     "# In this example, we sort to identify the brightest sources\n",
-    "cat.sort('MAG_F1392')\n",
-    "cat"
+    "cat = Table.read(outputfile, format='ascii.sextractor')\n",
+    "cat.sort(f'MAG_F{pivot_wave}')\n",
+    "cols_to_show = ['NUMBER', 'X_IMAGE', 'Y_IMAGE', 'A_IMAGE', 'B_IMAGE', 'MAG_F986', 'MAGERR_ISO']\n",
+    "cat[cols_to_show].show_in_notebook()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c6b64214",
    "metadata": {},
    "source": [
     "# 3. Running HSTaXe<a id=\"aXe\"></a>\n",
     "\n",
-    "With the catalog generated, we can now move on to working with HSTaXe. We'll set up some directories and environment variables that point to them, while clearing out any previous data or outputs in these directories. We won't clear the `CONF` directory, which contains configuration files with information that HSTaXe will use to locate the spectra in our grism images. We'll also copy our data into the fresh `DATA` directory."
+    "With the catalog generated and edited, we can now move on to working with HSTaXe. We'll set up a few additional directories and environment variables that point to them, while clearing out any previous data or outputs in these directories. We'll also copy our data into the fresh `DATA` directory."
    ]
   },
   {
@@ -405,44 +471,27 @@
    "source": [
     "os.chdir(cwd)\n",
     "\n",
-    "# DATA\n",
-    "if os.path.isdir('DATA'):\n",
-    "    shutil.rmtree('DATA')\n",
-    "os.mkdir('DATA')\n",
+    "for dirr in ['DATA','CONF','OUTPUT']:\n",
+    "    if os.path.isdir(dirr):\n",
+    "        shutil.rmtree(dirr)\n",
+    "    os.mkdir(dirr)\n",
+    "    \n",
     "os.environ['AXE_IMAGE_PATH'] = './DATA/' \n",
+    "os.environ['AXE_CONFIG_PATH'] = './CONF/'\n",
+    "os.environ['AXE_OUTPUT_PATH'] = './OUTPUT/'\n",
     "\n",
-    "src = 'direct_ims/*flt.fits'\n",
-    "dst = 'DATA'\n",
-    "for f in glob.glob(src):\n",
-    "    shutil.copy(f, dst)\n",
-    "src = 'grism_ims/*flt.fits'\n",
-    "for f in glob.glob(src):\n",
-    "    shutil.copy(f, dst)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "294de348",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# CONF\n",
-    "os.environ['AXE_CONFIG_PATH'] = './CONF/'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e826fd3f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# OUTPUT\n",
-    "if os.path.isdir('OUTPUT'):\n",
-    "    shutil.rmtree('OUTPUT')\n",
-    "os.mkdir('OUTPUT')\n",
-    "os.environ['AXE_OUTPUT_PATH'] = './OUTPUT/'"
+    "dsrc = 'direct_ims/*flt.fits'\n",
+    "gsrc = 'grism_ims/*flt.fits'\n",
+    "csrc = 'WFC3_IR_conf/*'\n",
+    "\n",
+    "for files in [dsrc, gsrc, csrc]:\n",
+    "    if '_ims' in files:\n",
+    "        dirr = 'DATA'\n",
+    "    elif 'config' in files:\n",
+    "        dirr = 'CONF'\n",
+    "    for f in glob.glob(files):\n",
+    "        shutil.copy(f, dirr)\n",
+    "    "
    ]
   },
   {
@@ -484,7 +533,7 @@
     "os.chdir('direct_ims')\n",
     "\n",
     "axetasks.iolprep(drizzle_image = 'direct_drz.fits',\n",
-    "                input_cat = 'aXe.cat',\n",
+    "                input_cat = 'aXe_ir_f098m.cat',\n",
     "                dimension_in = FOV)"
    ]
   },
@@ -502,15 +551,16 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2e616117",
    "metadata": {},
    "source": [
     "The last step before extracting our spectra is to generate a file which contains on each line the names of a grism image, IOL name, and associated direct image. This is best done manually, to ensure that each grism image lines up with the appropriate direct image. For the example data, a file called `example.lis` is provided.\n",
     "\n",
-    "With this list, we run `axeprep`, which prepares the individual images for spectral extraction. This step is also responsible for perfoming a global background subtraction, if desired. This is controlled by the `backgr` keyword.\n",
+    "With this list, we run `axeprep`, which prepares the individual images for spectral extraction. This step is also responsible for perfoming a global background subtraction, if desired. This is controlled by the `backgr` keyword. \n",
     "\n",
-    "Note that the `configs` and `backims` keywords should be matched to the data you have. E.g., if you are working with G102 data with direct images in F098M, the config file should be `G102.F098M.V4.31.conf`. If you are not performing a global background subtraction, `backims` is not required, but should be matched to the correct grism if you are."
+    "Note that the `configs` and `backims` keywords should be matched to the data you have. E.g., if you are working with G102 data with direct images in F098M, the config file should be `G102.F098M.V4.32.conf`. If you are not performing a global background subtraction, `backims` is not required, but should be matched to the correct grism if you are. **Note: we do not currently recommend using HSTaXe to perform global background subtraction. A more reliable method will be added to this notebook in the near future.**"
    ]
   },
   {
@@ -520,10 +570,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Uncomment below to copy and rename the example list file\n",
-    "# os.chdir(cwd)\n",
-    "# shutil.copy('example_data/example.lis', '.')\n",
-    "# os.rename('example.lis', 'aXe.lis')"
+    "# copy the example list file\n",
+    "os.chdir(cwd)\n",
+    "shutil.copy('example_data/example.lis', '.')\n",
+    "os.rename('example.lis', 'aXe.lis')"
    ]
   },
   {
@@ -536,8 +586,7 @@
     "os.chdir(cwd)\n",
     "\n",
     "axetasks.axeprep(inlist='aXe.lis',\n",
-    "                     configs='G141.F140W.V4.31.conf',\n",
-    "                     backims='WFC3.IR.G141.sky.V1.0.fits',\n",
+    "                     configs='G102.F098M.V4.32.conf',\n",
     "                     backgr=False,\n",
     "                     norm=False,\n",
     "                     mfwhm=3.0)"
@@ -568,11 +617,10 @@
    "outputs": [],
    "source": [
     "axetasks.axecore('aXe.lis',\n",
-    "                 'G141.F140W.V4.31.conf',\n",
-    "                 fconfterm='WFC3.IR.G141.sky.V1.0.fits',\n",
+    "                 'G102.F098M.V4.32.conf',\n",
+    "                 fconfterm=None,\n",
     "                 extrfwhm=4.,\n",
     "                 drzfwhm=3.,\n",
-    "                 backfwhm=5.,\n",
     "                 orient=False,\n",
     "                 back=False,\n",
     "                 weights=True,\n",
@@ -583,6 +631,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6ef080fa",
    "metadata": {},
@@ -591,20 +640,9 @@
     "\n",
     "Each grism input file will have several corresponding output files. For now, let's take a look at the STP files, which contain 2D \"stamps\" of the extracted spectral traces; and the SPC files, which contain our 1D extracted spectra.\n",
     "\n",
-    "We'll need the line numbers from the original source catalog we generated to identify the BEAM number for the objects whose spectra we want. For the example data, we'll use the bright star in the bottom-left of the direct images, which is on line 239 in the provided catalog.\n",
+    "We'll need the line numbers from the original source catalog we generated to identify the BEAM number for the object whose spectrum we want. For the example data, The target is the bright planetary nebula in the middle-left of the drizzled direct image. Its number in the example catalog is 19.\n",
     "\n",
-    "We'll first look at the STP files:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c3ca780b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ls OUTPUT/*SPC.fits\n",
-    "!ls OUTPUT/*STP.fits"
+    "First, let's examine the stamps from the STP files."
    ]
   },
   {
@@ -614,26 +652,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "beam = '239'\n",
+    "beam = '19'\n",
     "\n",
-    "fig, axes = plt.subplots(4, 1, figsize=(12,9))\n",
+    "fig, axes = plt.subplots(3, 1, figsize=(10,6))\n",
     "\n",
     "for i, f in enumerate(glob.glob('OUTPUT/*STP.fits')):\n",
     "    with fits.open(f) as hdul:\n",
     "        d = hdul[f'BEAM_{beam}A'].data\n",
-    "        im = axes[i].imshow(d, origin='lower')\n",
+    "        z1,z2 = zscale.zscale(d)\n",
+    "        im = axes[i].imshow(d, origin='lower', cmap='Greys_r', vmin=z1, vmax=z2)\n",
     "        axes[i].set_title(os.path.basename(f))\n",
-    "        im.set_clim(0, 5.0)\n",
     "        \n",
     "plt.tight_layout()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "05fa703c",
    "metadata": {},
    "source": [
-    "And now, the SPC files:"
+    "And now, we can finally look at our extracted spectra from the SPC files. For the example data, we've plotted the expected location of several emission lines that should be present in the planetary nebula spectrum (from Table 2 in [Bohlin et al. 2015](https://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/wfc3/documentation/instrument-science-reports-isrs/_documents/2015/WFC3-2015-10.pdf))."
    ]
   },
   {
@@ -643,9 +682,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "beam = '239'\n",
-    "\n",
-    "fig, axes = plt.subplots(4, 1, figsize=(12,12), sharex=True)\n",
+    "fig, ax = plt.subplots(1,1, figsize=(10,6), dpi=150)\n",
     "\n",
     "for i, f in enumerate(glob.glob('OUTPUT/*2.SPC.fits')):\n",
     "    with fits.open(f) as hdul:\n",
@@ -653,12 +690,21 @@
     "        wl = d['LAMBDA']\n",
     "        flux = d['FLUX']\n",
     "        error = d['FERROR']\n",
-    "        xrange = (wl>11500) & (wl<16000)\n",
-    "        axes[i].errorbar(wl[xrange],flux[xrange],error[xrange])\n",
-    "        axes[i].set_title(os.path.basename(f))\n",
-    "        axes[i].set_ylabel(r'Flux ($erg/s/cm^2/\\AA/s$)')        \n",
-    "axes[3].set_xlabel(r'Wavelength ($\\AA$)')\n",
+    "        contam = d['CONTAM']\n",
+    "        xrange = (wl>8000) & (wl<11500)\n",
     "        \n",
+    "        ax.errorbar(wl[xrange],flux[xrange],error[xrange], label=f'{os.path.basename(f)}')\n",
+    "        \n",
+    "# ax.set_title(os.path.basename(f))\n",
+    "ax.axvline(9070.0, ls=':', c='k') # SIII\n",
+    "ax.axvline(9535.1, ls=':', c='k') # SIII+P epsilon\n",
+    "ax.axvline(10060.2, ls=':', c='k') # HI P7\n",
+    "ax.axvline(10833.5, ls=':', c='k') # HeI\n",
+    "\n",
+    "\n",
+    "ax.set_ylabel(r'Flux ($erg/cm^2/s/\\AA$)')\n",
+    "ax.set_xlabel(r'Wavelength ($\\AA$)')\n",
+    "ax.legend(loc='upper left')\n",
     "plt.tight_layout()"
    ]
   },
@@ -679,18 +725,19 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9a339b9d",
    "metadata": {},
    "source": [
     "## About this Notebook <a id=\"about\"></a>\n",
     "\n",
-    "**Author:** Aidan Pidgeon, WFC3 Instrument Team\n",
+    "**Author:** Aidan Pidgeon and Benjamin Kuhn, WFC3 Instrument Team\n",
     "\n",
     "**Special Thanks to:** \n",
     " - Dr. Nor Pirzkal, for creating the original workflow that was adapted into this notebook\n",
     " - Ricky O'Steen and Duy Nguyen, for their fantastic work in updating the HSTaXe module\n",
-    " - Debopam Som and Benjamin Kuhn, for support in testing the HSTaXe workflow\n",
+    " - Debopam Som, for support in testing the HSTaXe workflow\n",
     "\n",
     "**Updated On:** 2022-01-06\n",
     "\n",
@@ -714,7 +761,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "hstaxe_cookbook",
    "language": "python",
    "name": "python3"
   },
@@ -728,7 +775,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "61185e4153bd22ba192429d01ef156e5c02e7fcbb7ff0f03ca08685bc8232e35"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes to workflow ensure that the user, after downloading all example data and conf files from Box, should be able to run through the notebook without stopping. Updated relevant links and changed example data to G102. Also changed some plotting commands to produce nicer results.