### PR TITLE
Add comment from helpdesk ticket resolution

### DIFF
--- a/docs/hstaxe/installing.rst
+++ b/docs/hstaxe/installing.rst
@@ -41,6 +41,14 @@ failed install step:
 .. code-block:: bash
 
     conda install hdf5 -c conda-forge
+
+Some users have also reported needing to install ``openblas`` in order to get a successful
+install working. If you have followed the rest of the ``hstaxe`` installation instructions
+and are still having problems, it may be worth adding the following command at this step:
+
+.. code-block:: bash
+
+    conda install openblas -c conda-forge
     
 Installing HSTaXe
 -----------------


### PR DESCRIPTION
A user opened a ticket on the STScI helpdesk with a problem installing `hstaxe`. They eventually got the install working but had to install `openblas` to do it, so I added a note that users might need to install this package to the documentation.