### PR TITLE
Update cookbook_env.yml

### DIFF
--- a/cookbooks/cookbook_env.yml
+++ b/cookbooks/cookbook_env.yml
@@ -15,7 +15,7 @@ dependencies:
 - python>=3.8,<3.11
 - pip:
     - crds
-    - ginga
+    - ginga<4.1
     - jupyter
     - acstools
     - git+https://github.com/spacetelescope/wfc3tools.git


### PR DESCRIPTION
pinning `ginga` at <4.1 to avoid `zscale` import error