### PR TITLE
fix typo in IR cookbook

### DIFF
--- a/cookbooks/WFC3/IR_extraction/wfc3-ir-hstaxe-cookbook.ipynb
+++ b/cookbooks/WFC3/IR_extraction/wfc3-ir-hstaxe-cookbook.ipynb
@@ -4190,9 +4190,9 @@
    "id": "0058a1c3",
    "metadata": {},
    "source": [
-    "Examine the catalog. The \"MAG_ISO\" column must be renamed to \"MAG_F####\" for the catalog to be correctly read in by HSTaXe. Where \"####\" is the pivot wavelength of the direct image filter in nm (Å for WFC3/UVIS, e.g. 4971 for F200LP and 1392 for F140W). Please see WFC3 Instrument Handbook Section 7.5 [\"IR Spectral Elements\"](https://hst-docs.stsci.edu/wfc3ihb/chapter-7-ir-imaging-with-wfc3/7-5-ir-spectral-elements) for information about UVIS filter pivot wavelengths. You can also refer to the table above as a quick-reference for the pivot wavelength of the recommended direct image filters for the IR grisms.\n",
+    "Examine the catalog. The \"MAG_ISO\" column must be renamed to \"MAG_F####\" for the catalog to be correctly read in by HSTaXe. Where \"####\" is the pivot wavelength of the direct image filter in nm (Å for WFC3/UVIS, e.g. 4971 for F200LP and 1392 for F140W). Please see WFC3 Instrument Handbook Section 7.5 [\"IR Spectral Elements\"](https://hst-docs.stsci.edu/wfc3ihb/chapter-7-ir-imaging-with-wfc3/7-5-ir-spectral-elements) for information about IR filter pivot wavelengths. You can also refer to the table above as a quick-reference for the pivot wavelength of the recommended direct image filters for the IR grisms.\n",
     "\n",
-    "Any lines in the catalog containing clearly spurious detections, such as those with magnitudes of 99.0, should also be removed. **Note**: Removing spurious detections is not apart of this notebook and will need to be done manually. \n",
+    "Any lines in the catalog containing clearly spurious detections, such as those with magnitudes of 99.0, should also be removed. **Note**: Removing spurious detections is not a part of this notebook and will need to be done manually. \n",
     "\n",
     "\n",
     "Lastly, locate the lines containing the sources whose spectra you want to extract and note the line number from the NUMBER column. This will be used later to identify the BEAM number for your object in the output files."


### PR DESCRIPTION
The IR cookbook has a typo left over from our UVIS version. We are linking to the correct section of the handbook for IR filter pivot wavelengths but accidentally say "UVIS" in the text.