### PR TITLE
add updatewcs import and fix typos for UVIS fullframe cookbook

### DIFF
--- a/cookbooks/WFC3/UVIS_fullframe_basic_extraction/wfc3-basic-uvis-fullframe-hstaxe-cookbook.ipynb
+++ b/cookbooks/WFC3/UVIS_fullframe_basic_extraction/wfc3-basic-uvis-fullframe-hstaxe-cookbook.ipynb
@@ -46,13 +46,13 @@
    "source": [
     "## 1. Introduction <a id=\"intro\"></a>\n",
     "\n",
-    "[HSTaXe](https://hstaxe.readthedocs.io/en/latest/index.html) is a Python package that provides spectral extraction processes for HST data. **Please be aware that running this notebook requires creating a conda environment from the provided `.yml` file in this notebook's [github repository](https://github.com/spacetelescope/hstaxe/tree/main/cookbooks).** For more details about creating the necessary environment see the notebook's README file.\n",
+    "[HSTaXe](https://hstaxe.readthedocs.io/en/latest/index.html) is a Python package that provides spectral extraction processes for HST data. **Please be aware that running this notebook requires creating a conda environment from the provided `.yml` file in this notebook's [github repository](https://github.com/spacetelescope/hstaxe/tree/main/cookbooks).** For more details about creating the necessary environment, see the notebook's README file.\n",
     "\n",
-    "Below, we show the workflow for a basic specral extraction using WFC3/UVIS full frame G280 grism data. **The example data we use in this notebook are available [here](https://stsci.box.com/s/x0ndoduqkqd1ys1u9fgsz32urizsjdks).** If you would like to use this notebook with the example data, please dowload all required data in the `example_data` subdirectory from the link above, and store it within the same parent directory as this notebook. Once you have the example data directory, this notebook is intended to run continuously without needing to edit any of the cells. \n",
+    "Below, we show the workflow for a basic spectral extraction using WFC3/UVIS full frame G280 grism data. **The example data we use in this notebook are available [here](https://stsci.box.com/s/x0ndoduqkqd1ys1u9fgsz32urizsjdks).** If you would like to use this notebook with the example data, please download all required data in the `example_data` subdirectory from the link above, and store it within the same parent directory as this notebook. Once you have the example data directory, this notebook is intended to run continuously without needing to edit any of the cells. \n",
     "\n",
-    "In addition to the grism and direct image data, **this notebook also requires configuration files for HSTaXe, which can be downloaded [here](https://stsci.box.com/s/ojbj3v4twkpkqt6tj9hwg1xkzbhrugm4).** Please download the folder titled `WFC3_UVIS_conf`. This configuration directory should be stored in the  same parent directory as this notebook, and later we will be copy them to the `CONF` subdirectory created by HSTaXe.\n",
+    "In addition to the grism and direct image data, **this notebook also requires configuration files for HSTaXe, which can be downloaded [here](https://stsci.box.com/s/ojbj3v4twkpkqt6tj9hwg1xkzbhrugm4).** Please download the folder titled `WFC3_UVIS_conf`. This configuration directory should be stored in the  same parent directory as this notebook, and later we will be copying them to the `CONF` subdirectory created by HSTaXe.\n",
     "\n",
-    "**If you plan to use your own data with this notebook, please be aware you will be required to create an input source catalog with SExtractor.** Information regarding SExtractor including installation instructions are available [here](https://sextractor.readthedocs.io/en/latest/Installing.html). In addition to installing SExtractor, you must run the software with aXe specific configuration files. **These aXe-SExtractor configuration files can be downloaded [here](https://stsci.box.com/s/3npry36gu7ocfnuxgzwr5syj4i8r7hy8).** Once SExtractor is installed, create a `sextractor` directory in the same parent directory as this notebook, and place configuration files inside. "
+    "**If you plan to use your own data with this notebook, please be aware you will be required to create an input source catalog with SExtractor.** Information regarding SExtractor, including installation instructions, is available [here](https://sextractor.readthedocs.io/en/latest/Installing.html). In addition to installing SExtractor, you must run the software with aXe-specific configuration files. **These aXe-SExtractor configuration files can be downloaded [here](https://stsci.box.com/s/3npry36gu7ocfnuxgzwr5syj4i8r7hy8).** Once SExtractor is installed, create a `sextractor` directory in the same parent directory as this notebook, and place configuration files inside. "
    ]
   },
   {
@@ -71,6 +71,7 @@
     "- *ginga.util.zscale* for calculating zscale limits for image display\n",
     "- *astrodrizzle* for creating input image mosaics\n",
     "- *hstaxe.axetasks* for performing the spectral extraction\n"
+    "- *stwcs.updatewcs* for resetting file's WCS\n"
    ]
   },
   {
@@ -92,7 +93,8 @@
     "from ginga.util import zscale\n",
     "\n",
     "from drizzlepac import astrodrizzle\n",
-    "from hstaxe import axetasks"
+    "from hstaxe import axetasks\n",
+    "from stwcs import updatewcs"
    ]
   },
   {
@@ -495,9 +497,9 @@
    "id": "0058a1c3",
    "metadata": {},
    "source": [
-    "Examine the catalog. The \"MAG_ISO\" column must be renamed to \"MAG_F####\" for the catalog to be correctly read in by HSTaXe. Where \"####\" is the pivot wavelength of the direct image filter in Å (and nm for WFC3/IR e.g. 4971 for F200LP and 1392 for F140W). Please see the [WFC3/UVIS photometic calibration webpage](https://www.stsci.edu/hst/instrumentation/wfc3/data-analysis/photometric-calibration/uvis-photometric-calibration) for pivot wavelengths, which are listed in the `PHOTPLAM` column in the accordion container. \n",
+    "Examine the catalog. The \"MAG_ISO\" column must be renamed to \"MAG_F####\" for the catalog to be correctly read in by HSTaXe. Where \"####\" is the pivot wavelength of the direct image filter in Å (and nm for WFC3/IR e.g. 4971 for F200LP and 1392 for F140W). Please see the [WFC3/UVIS photometric calibration webpage](https://www.stsci.edu/hst/instrumentation/wfc3/data-analysis/photometric-calibration/uvis-photometric-calibration) for pivot wavelengths, which are listed in the `PHOTPLAM` column in the accordion container. \n",
     "\n",
-    "Any lines in the catalog containing clearly spurious detections, such as those with magnitudes of $\\pm$99, should also be removed. **Note**: Removing spurious detections is not apart of this notebook and will need to be done manually. \n",
+    "Any lines in the catalog containing clearly spurious detections, such as those with magnitudes of $\\pm$99, should also be removed. **Note**: Removing spurious detections is not a part of this notebook and will need to be done manually. \n",
     "\n",
     "Lastly, locate the lines containing the sources whose spectra you want to extract and note the line number from the NUMBER column. This will be used later to identify the BEAM number for your object in the output files."
    ]

--- a/cookbooks/WFC3/UVIS_fullframe_basic_extraction/wfc3-basic-uvis-fullframe-hstaxe-cookbook.ipynb
+++ b/cookbooks/WFC3/UVIS_fullframe_basic_extraction/wfc3-basic-uvis-fullframe-hstaxe-cookbook.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "## 1. Introduction <a id=\"intro\"></a>\n",
     "\n",
-    "[HSTaXe](https://hstaxe.readthedocs.io/en/latest/index.html) is a Python package that provides spectral extraction processes for HST data. **Please be aware that running this notebook requires creating a conda environment from the provided `.yml` file in this notebook's [github repository](https://github.com/spacetelescope/hstaxe/tree/main/cookbooks).** For more details about creating the necessary environment, see the notebook's README file.\n",
+    "[HSTaXe](https://hstaxe.readthedocs.io/en/latest/index.html) is a Python package that provides spectral extraction processes for HST data. **Please be aware that running this notebook requires creating a conda environment from the provided `.yml` file in this notebook's [github repository](https://github.com/spacetelescope/hstaxe/tree/main/cookbooks).** For more details about creating the necessary environment see the notebook's README file.\n",
     "\n",
     "Below, we show the workflow for a basic spectral extraction using WFC3/UVIS full frame G280 grism data. **The example data we use in this notebook are available [here](https://stsci.box.com/s/x0ndoduqkqd1ys1u9fgsz32urizsjdks).** If you would like to use this notebook with the example data, please download all required data in the `example_data` subdirectory from the link above, and store it within the same parent directory as this notebook. Once you have the example data directory, this notebook is intended to run continuously without needing to edit any of the cells. \n",
     "\n",
@@ -70,8 +70,9 @@
     "- *matplotlib.pyplot* for plotting\n",
     "- *ginga.util.zscale* for calculating zscale limits for image display\n",
     "- *astrodrizzle* for creating input image mosaics\n",
-    "- *hstaxe.axetasks* for performing the spectral extraction\n"
-    "- *stwcs.updatewcs* for resetting file's WCS\n"
+    "- *hstaxe.axetasks* for performing the spectral extraction\n",
+    "- *stwcs.updatewcs* for resetting file's WCS\n",
+    "  "
    ]
   },
   {
@@ -939,7 +940,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.10.9"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
This cookbook was missing the `from stwcs import updatewcs` line, which causes an error when the `check_wcs()` function is called. I also fixed various typos/grammatical mistakes