### PR TITLE
Add note about Docker image to docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,10 @@
-FROM ubuntu
+FROM continuumio/miniconda3
 
-RUN apt-get update && apt-get install -yq curl && apt-get install -y build-essential && apt-get install -y git
+RUN apt-get update && apt-get install -y build-essential && apt-get install -y git
 
-RUN curl -O https://repo.anaconda.com/archive/Anaconda3-2025.06-0-Linux-x86_64.sh
-RUN bash Anaconda3-2025.06-0-Linux-x86_64.sh -b -p /anaconda3
-RUN rm Anaconda3-2025.06-0-Linux-x86_64.sh
-RUN source /anaconda3/bin/activate
-RUN conda init --all
+COPY docker_env.yml /tmp/env.yaml
 
-RUN conda create --name hstaxe-env python=3.10 pip
-RUN conda activate hstaxe-env
-RUN conda install gsl cfitsio make automake autoconf libtool pkg-config -y
-RUN conda install wcstools -c https://conda.anaconda.org/conda-forge/ --override-channels -y
-RUN pip install hstaxe --no-cache-dir
-RUN pip install crds "ginga<4.1" acstools jupyter "git+https://github.com/spacetelescope/wfc3tools.git"
-
-RUN git clone https://github.com/spacetelescope/hstaxe.git
-
-EXPOSE 8888
-
-CMD ["jupyter", "notebook", "--allow-root", "--notebook-dir=/hstaxe/cookbooks", "--ip='*'", "--port=8888", "--no-browser"]
+RUN conda env create -n hstaxe_env -f /tmp/env.yaml
+RUN rm -rf /opt/conda/pkgs/*
+RUN echo "source activate hstaxe_env" > ~/.bashrc
+ENV PATH /opt/conda/envs/hstaxe_env/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu
+
+RUN apt-get update && apt-get install -yq curl && apt-get install -y build-essential && apt-get install -y git
+
+RUN curl -O https://repo.anaconda.com/archive/Anaconda3-2025.06-0-Linux-x86_64.sh
+RUN bash Anaconda3-2025.06-0-Linux-x86_64.sh -b -p /anaconda3
+RUN rm Anaconda3-2025.06-0-Linux-x86_64.sh
+RUN source /anaconda3/bin/activate
+RUN conda init --all
+
+RUN conda create --name hstaxe-env python=3.10 pip
+RUN conda activate hstaxe-env
+RUN conda install gsl cfitsio make automake autoconf libtool pkg-config -y
+RUN conda install wcstools -c https://conda.anaconda.org/conda-forge/ --override-channels -y
+RUN pip install hstaxe --no-cache-dir
+RUN pip install crds "ginga<4.1" acstools jupyter "git+https://github.com/spacetelescope/wfc3tools.git"
+
+RUN git clone https://github.com/spacetelescope/hstaxe.git
+
+EXPOSE 8888
+
+CMD ["jupyter", "notebook", "--allow-root", "--notebook-dir=/hstaxe/cookbooks", "--ip='*'", "--port=8888", "--no-browser"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ https://github.com/spacetelescope/slitlessutils and https://slitlessutils.readth
 for your work, and please give us feedback on the new tool and how we can best support your
 transition to using Slitlessutils.
 
+A stable, working version of HSTaXe is available as a Docker image at
+https://stsci.box.com/shared/static/6a75go3d0yqc627bts2yuqk0veancylh.tar. To load this image into
+your local Docker instance, use the command `docker load --input hstaxe_docker_image.tar`. Note
+that the image is only available as a Linux x86_64 platform, so you may experience poorer
+performance if running the image on a machine with a different architecture (e.g. a Mac with
+ARM64 architecture).
+
 HSTaXe
 ======
 

--- a/docker_env.yml
+++ b/docker_env.yml
@@ -1,0 +1,23 @@
+name: hstaxe_env
+channels:
+- defaults
+dependencies:
+- autoconf
+- automake
+- cfitsio
+- gsl
+- libtool
+- make
+- pip
+- pkg-config
+- python=3.10
+- conda-forge::hstcal>=2.7.2
+- conda-forge::wcstools
+- pip:
+    - crds
+    - ginga<4.1
+    - jupyter
+    - acstools
+    - numpy<2.0
+    - git+https://github.com/spacetelescope/wfc3tools.git
+    - git+https://github.com/spacetelescope/hstaxe.git

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,13 @@ HSTaXe is the successor to aXe, a similar package written on PyRAF/IRAF.
    for your work, and please give us feedback on the new tool and how we can best support your
    transition to using Slitlessutils.
 
+   A stable, working version of HSTaXe is available as a Docker image at
+   https://stsci.box.com/shared/static/6a75go3d0yqc627bts2yuqk0veancylh.tar. To load this image into
+   your local Docker instance, use the command `docker load --input hstaxe_docker_image.tar`. Note
+   that the image is only available as a Linux x86_64 platform, so you may experience poorer
+   performance if running the image on a machine with a different architecture (e.g. a Mac with
+   ARM64 architecture).
+
 .. warning::
    This documentation mostly overlaps with, but is not identical to, the original
    aXe manual. This means that many of the descriptions and code snippets provided


### PR DESCRIPTION
For now I put the Docker image on Box, if we figure out how to make it public through the `spacetelescope` Docker org I'll update the docs.